### PR TITLE
feat: RecruitmentListItem 북마크 버튼 추가 및 링크/액션 영역 분리

### DIFF
--- a/src/features/recruitment/components/ui/RecruitmentListItem.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentListItem.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Sparkles, Calendar, Briefcase } from 'lucide-react';
 import { formatDeadline } from '@/shared/utils/formatDeadline';
+import BookmarkButton from '@/features/recruitment/components/ui/BookmarkButton';
 
 interface RecruitmentListItemProps {
   postId: number | string;
@@ -9,6 +10,7 @@ interface RecruitmentListItemProps {
   experienceLevel: number | undefined;
   companyName: string;
   analysisSummary?: string | null;
+  initialBookmarked?: boolean;
 }
 
 export default function RecruitmentListItem({
@@ -18,39 +20,46 @@ export default function RecruitmentListItem({
   experienceLevel,
   companyName,
   analysisSummary,
+  initialBookmarked = false,
 }: RecruitmentListItemProps) {
   return (
-    <Link
-      href={`/recruitment/${postId}`}
-      className="flex items-center justify-between rounded-lg border-gray-100 p-5 hover:bg-gray-50"
-    >
-      <div className="flex flex-col gap-2">
-        <span className="text-base font-semibold text-gray-900">{title}</span>
+    <div className="flex items-center justify-between rounded-lg border-gray-100 p-5 hover:bg-gray-50">
+      <Link href={`/recruitment/${postId}`} className="min-w-0 flex-1">
+        <div className="flex min-w-0 flex-col gap-2">
+          <span className="truncate text-base font-semibold text-gray-900">{title}</span>
 
-        {analysisSummary && (
-          <div className="flex items-center gap-1.5">
-            <Sparkles className="h-3.5 w-3.5 text-blue-500" />
-            <span className="text-[13px] font-medium text-blue-500">{analysisSummary}</span>
-          </div>
-        )}
+          {analysisSummary && (
+            <div className="flex items-center gap-1.5">
+              <Sparkles className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+              <span className="truncate text-[13px] font-medium text-blue-500">
+                {analysisSummary}
+              </span>
+            </div>
+          )}
 
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-1">
-            <Calendar className="h-3 w-3 text-gray-400" />
-            <span className="text-xs text-gray-500">{formatDeadline(deadline)}</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <Briefcase className="h-3 w-3 text-gray-400" />
-            <span className="text-xs text-gray-500">
-              {experienceLevel === 0 ? '신입' : `경력 ${experienceLevel}년 이상`}
-            </span>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-1">
+              <Calendar className="h-3 w-3 text-gray-400" />
+              <span className="text-xs text-gray-500">{formatDeadline(deadline)}</span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <Briefcase className="h-3 w-3 text-gray-400" />
+              <span className="text-xs text-gray-500">
+                {experienceLevel === 0 ? '신입' : `경력 ${experienceLevel}년 이상`}
+              </span>
+            </div>
           </div>
         </div>
-      </div>
+      </Link>
 
-      <span className="shrink-0 rounded bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700">
-        {companyName}
-      </span>
-    </Link>
+      <div className="ml-4 flex shrink-0 items-center gap-2">
+        <span className="rounded bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700">
+          {companyName}
+        </span>
+
+        <BookmarkButton postId={postId} initialBookmarked={initialBookmarked} variant="icon" />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## 작업 내용

- `RecruitmentListItem`에 북마크 아이콘 버튼 추가
  - 우측 액션 영역에 회사명 배지/북마크 버튼 배치
  - `initialBookmarked` props 추가 및 초기 상태 반영
- 전체 Link 래핑 구조를 본문 링크/액션 영역으로 분리
  - 상세 이동과 북마크 클릭 충돌 방지를 위한 인터랙션 책임 분리
  - 링크 중심 아이템에서 액션을 수용할 수 있는 카드 구조로 개선

## 리뷰 필요

- `initialBookmarked` 초기 상태 반영 방식과 우측 액션 영역 레이아웃(배지/버튼 배치)이 확장 관점에서 적절한지 확인 부탁드립니다.

close #34