### PR TITLE
fix: Header 검색바 Suspense boundary 적용으로 빌드 에러 해결

### DIFF
--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import SearchBar from '@/shared/components/ui/SearchBar';
 import ProfileMenu from '@/features/auth/components/ui/ProfileMenu';
+import { Suspense } from 'react';
 
 export default function Header() {
   const currentPath = usePathname();
@@ -46,7 +47,9 @@ export default function Header() {
 
         {showSearchBar && (
           <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-            <SearchBar />
+            <Suspense fallback={null}>
+              <SearchBar />
+            </Suspense>
           </div>
         )}
 


### PR DESCRIPTION
## 작업 내용

- `Header` 내 `SearchBar`를 `Suspense boundary`로 감싸도록 수정
- `useSearchParams` 사용으로 인해 `/` 페이지 prerender 시 발생하던 빌드 에러 해결

## 리뷰 필요

- 없음

close #44