### PR TITLE
feat: 공고 목록 페이지에 조건별 공고 개수 표시

### DIFF
--- a/src/features/recruitment/components/sections/RecruitmentListSection.tsx
+++ b/src/features/recruitment/components/sections/RecruitmentListSection.tsx
@@ -51,7 +51,15 @@ export default function RecruitmentListSection({ activeTab, search }: Recruitmen
       {filteredRecruitments.length === 0 ? (
         <RecruitmentEmptyState search={search} />
       ) : (
-        <RecruitmentList recruitments={filteredRecruitments} />
+        <div className="flex flex-1 flex-col">
+          <div className="mb-4 flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-900">
+              <span className="text-blue-500">{filteredRecruitments.length}개</span>의 공고가
+              열려있어요.
+            </span>
+          </div>
+          <RecruitmentList recruitments={filteredRecruitments} />
+        </div>
       )}
     </section>
   );


### PR DESCRIPTION
## 작업 내용

- 현재 탭/검색 조건에 맞는 공고 개수를 목록 상단에 노출

## 리뷰 필요

- 현재는 조회되는 공고가 없어 개수 노출 화면을 확인하기 어렵습니다.

close #50 
