### PR TITLE
fix: 공고 목록/상세 조회를 비로그인 접근 가능하도록 수정

### DIFF
--- a/src/features/recruitment/actions.ts
+++ b/src/features/recruitment/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { privateFetch } from '@/shared/api/httpClient';
+import { privateFetch, publicFetch } from '@/shared/api/httpClient';
 import { ApiResponse } from '@/shared/types/api';
 import {
   GetRecruitmentDetailResponse,
@@ -21,14 +21,14 @@ export async function getRecruitments(
   if (params.size) searchParams.set('size', String(params.size));
   const query = searchParams.toString();
 
-  return await privateFetch<GetRecruitmentsResponse>(`/api/v1/posts${query ? `?${query}` : ''}`);
+  return await publicFetch<GetRecruitmentsResponse>(`/api/v1/posts${query ? `?${query}` : ''}`);
 }
 
 // 공고 상세 조회
 export async function getRecruitmentDetail(
   postId: number,
 ): Promise<ApiResponse<GetRecruitmentDetailResponse>> {
-  return await privateFetch<GetRecruitmentDetailResponse>(`/api/v1/posts/${postId}`, {
+  return await publicFetch<GetRecruitmentDetailResponse>(`/api/v1/posts/${postId}`, {
     next: { revalidate: 300, tags: ['recruitment', `recruitment-detail-${postId}`] },
   });
 }


### PR DESCRIPTION
## 작업 내용

- **비로그인 상태에서도 공고 목록/상세를 조회할 수 있도록 수정**
    - 공고 목록/상세 조회 API를 `privateFetch`에서 `publicFetch`로 변경

## 리뷰 필요

- 없음

close #103