### PR TITLE
fix: 기업 상세 조회를 비로그인 접근 가능하도록 수정

### DIFF
--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { privateFetch } from '@/shared/api/httpClient';
+import { publicFetch } from '@/shared/api/httpClient';
 import { ApiResponse } from '@/shared/types/api';
 import { GetCompanyDetailResponse } from '@/features/company/types';
 
@@ -8,7 +8,7 @@ import { GetCompanyDetailResponse } from '@/features/company/types';
 export async function getCompanyDetail(
   companyId: number,
 ): Promise<ApiResponse<GetCompanyDetailResponse>> {
-  return await privateFetch<GetCompanyDetailResponse>(`/api/v1/companies/${companyId}`, {
+  return await publicFetch<GetCompanyDetailResponse>(`/api/v1/companies/${companyId}`, {
     next: { revalidate: 300, tags: ['company', `company-detail-${companyId}`] },
   });
 }


### PR DESCRIPTION
## 작업 내용

- **비로그인 상태에서도 기업 상세를 조회할 수 있도록 수정**
    - 기업 상세 조회 API를 privateFetch에서 publicFetch로 변경

## 리뷰 필요

- 없음

close #108 
