### PR TITLE
refactor: 파일 크기 포맷 단위 확장

### DIFF
--- a/src/features/file/utils/formatFileSize.ts
+++ b/src/features/file/utils/formatFileSize.ts
@@ -1,4 +1,17 @@
 export function formatFileSize(bytes: number): string {
-  const mb = bytes / (1024 * 1024);
-  return `${mb < 0.1 ? mb.toFixed(2) : mb.toFixed(1)} MB`;
+  if (bytes === 0) return '0 B';
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  const formatted =
+    size < 10 ? size.toFixed(2) : size < 100 ? size.toFixed(1) : Math.round(size).toString();
+
+  return `${formatted} ${units[unitIndex]}`;
 }


### PR DESCRIPTION
## 작업 내용

- 파일 크기 표시 단위를 B, KB, MB, GB까지 확장
- 파일 크기에 따라 적절한 단위를 자동 선택하도록 포맷 로직 수정

## 리뷰 필요

- 없음

close #124