### PR TITLE
refactor: 기업 도메인 반응형 레이아웃 적용

### DIFF
--- a/src/app/(main)/company/[companyId]/page.tsx
+++ b/src/app/(main)/company/[companyId]/page.tsx
@@ -2,6 +2,8 @@ import CompanyDetailSection from '@/features/company/components/sections/Company
 import CompanyIndustryAnalysisSection from '@/features/company/components/sections/CompanyIndustryAnalysisSection';
 import { getCompanyDetail } from '@/features/company/actions';
 import { getIndustryAnalysis } from '@/features/industry/actions';
+import FloatingActionButton from '@/shared/components/ui/FloatingActionButton';
+import { Lightbulb } from 'lucide-react';
 
 interface CompanyDetailPageProps {
   params: Promise<{ companyId: string }>;
@@ -26,10 +28,24 @@ export default async function CompanyDetailPage({ params }: CompanyDetailPagePro
 
   return (
     <div className="flex min-h-screen w-full flex-col bg-white font-sans">
-      <div className="mx-auto flex w-full max-w-7xl items-start gap-10 px-4 py-10">
+      <div className="mx-auto flex w-full max-w-7xl items-start gap-10 px-4 py-10 max-lg:flex-col max-lg:items-stretch max-lg:gap-6 max-lg:py-7 max-md:py-6 max-md:pb-[calc(env(safe-area-inset-bottom)+7rem)]">
         <CompanyDetailSection company={company} />
         <CompanyIndustryAnalysisSection analysis={industryAnalysis} />
       </div>
+      <FloatingActionButton
+        href="/strategy/create"
+        ariaLabel="포트폴리오 전략 생성 페이지로 이동"
+        wrapperClassName="max-md:right-4 max-md:bottom-[calc(env(safe-area-inset-bottom)+1rem)]"
+        buttonClassName="bg-[#3182f6] hover:bg-[#2c74dd] border-transparent"
+        icon={<Lightbulb className="h-5 w-5 text-white" />}
+        label={
+          <>
+            포폴 전략
+            <br />
+            생성하러 가기
+          </>
+        }
+      />
     </div>
   );
 }

--- a/src/features/company/components/sections/CompanyDetailSection.tsx
+++ b/src/features/company/components/sections/CompanyDetailSection.tsx
@@ -8,7 +8,7 @@ interface CompanyDetailSectionProps {
 
 export default function CompanyDetailSection({ company }: CompanyDetailSectionProps) {
   return (
-    <div className="flex min-w-0 flex-1 flex-col">
+    <div className="flex min-w-0 flex-1 flex-col max-lg:w-full">
       <CompanyDetailOverview company={company} />
 
       <div className="h-px bg-gray-100" />

--- a/src/features/company/components/sections/CompanyIndustryAnalysisSection.tsx
+++ b/src/features/company/components/sections/CompanyIndustryAnalysisSection.tsx
@@ -12,13 +12,13 @@ export default function CompanyIndustryAnalysisSection({
   analysis,
 }: CompanyIndustryAnalysisSectionProps) {
   return (
-    <div className="flex w-110 shrink-0 flex-col">
+    <div className="flex w-full flex-col gap-6 max-lg:w-full lg:w-96 lg:shrink-0 lg:gap-5 xl:w-110 xl:gap-6">
       <div className="flex items-center gap-2 pb-4">
         <Sparkles className="h-4.5 w-4.5 text-blue-500" />
         <h2 className="text-lg font-bold text-gray-900">산업 분석</h2>
       </div>
       {analysis && (
-        <div className="flex items-center gap-3 text-xs text-gray-400 pb-7">
+        <div className="flex flex-wrap items-center gap-3 pb-7 text-xs text-gray-400 max-md:gap-2 max-md:pb-5">
           <span>분석 등록일 {formatAnalysisDateTime(analysis.createdAt)}</span>
           <span>·</span>
           <span>업데이트 {formatAnalysisDateTime(analysis.updatedAt)}</span>
@@ -26,7 +26,7 @@ export default function CompanyIndustryAnalysisSection({
       )}
 
       {analysis ? (
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6 lg:gap-5 xl:gap-6">
           <KeywordTagList
             title="핵심 산업 키워드"
             keywords={analysis.keyword.map((keyword) => `#${keyword}`)}

--- a/src/features/company/components/ui/CompanyDetailHeader.tsx
+++ b/src/features/company/components/ui/CompanyDetailHeader.tsx
@@ -8,15 +8,15 @@ interface CompanyDetailHeaderProps {
 
 export default function CompanyDetailHeader({ company }: CompanyDetailHeaderProps) {
   return (
-    <div className="flex items-center gap-4 pb-6">
-      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-gray-100">
+    <div className="flex items-center gap-4 pb-6 max-md:items-start max-md:gap-3 max-md:pb-5">
+      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-gray-100 max-md:h-12 max-md:w-12">
         <Building2 className="h-7 w-7 text-gray-400" />
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <span className="text-2xl font-bold text-gray-900">{company.companyName}</span>
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <span className="text-2xl font-bold text-gray-900 max-md:text-xl">{company.companyName}</span>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-1 rounded-md bg-blue-50 px-2.5 py-1">
             <span className="text-[12px] font-semibold text-blue-600">{company.industryName}</span>
           </div>

--- a/src/features/company/components/ui/CompanyMetaGrid.tsx
+++ b/src/features/company/components/ui/CompanyMetaGrid.tsx
@@ -8,9 +8,9 @@ interface CompanyMetaGridProps {
 
 export default function CompanyMetaGrid({ company }: CompanyMetaGridProps) {
   return (
-    <div className="grid grid-cols-2 gap-3 pb-6">
+    <div className="grid grid-cols-2 gap-3 pb-6 max-md:gap-2.5 max-md:pb-5">
       {company.employeeCount !== undefined && (
-        <div className="flex min-h-18 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5">
+        <div className="flex min-h-18 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5 max-md:min-h-15 max-md:items-start max-md:gap-2 max-md:px-3 max-md:py-2.5">
           <Users className="h-4 w-4 shrink-0 text-gray-400" />
           <div className="flex flex-col gap-0.5">
             <span className="text-[11px] text-gray-400">사원 수</span>
@@ -22,17 +22,19 @@ export default function CompanyMetaGrid({ company }: CompanyMetaGridProps) {
       )}
 
       {company.address && (
-        <div className="flex min-h-18 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5">
+        <div className="flex min-h-18 min-w-0 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5 max-md:min-h-15 max-md:items-start max-md:gap-2 max-md:px-3 max-md:py-2.5">
           <MapPin className="h-4 w-4 shrink-0 text-gray-400" />
-          <div className="flex flex-col gap-0.5">
+          <div className="flex min-w-0 flex-col gap-0.5">
             <span className="text-[11px] text-gray-400">주소지</span>
-            <span className="text-[13px] font-semibold text-gray-800">{company.address}</span>
+            <span className="break-words text-[13px] font-semibold text-gray-800 max-md:leading-snug">
+              {company.address}
+            </span>
           </div>
         </div>
       )}
 
       {company.foundedYear !== undefined && (
-        <div className="flex min-h-18 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5">
+        <div className="flex min-h-18 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5 max-md:min-h-15 max-md:items-start max-md:gap-2 max-md:px-3 max-md:py-2.5">
           <Calendar className="h-4 w-4 shrink-0 text-gray-400" />
           <div className="flex flex-col gap-0.5">
             <span className="text-[11px] text-gray-400">설립연도</span>
@@ -42,15 +44,15 @@ export default function CompanyMetaGrid({ company }: CompanyMetaGridProps) {
       )}
 
       {company.companyUrl && (
-        <div className="flex min-h-18 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5">
+        <div className="flex min-h-18 min-w-0 items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3.5 max-md:min-h-15 max-md:items-start max-md:gap-2 max-md:px-3 max-md:py-2.5">
           <Globe className="h-4 w-4 shrink-0 text-gray-400" />
-          <div className="flex flex-col gap-0.5">
+          <div className="flex min-w-0 flex-col gap-0.5">
             <span className="text-[11px] text-gray-400">홈페이지</span>
             <Link
               href={company.companyUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[13px] font-semibold text-blue-500 hover:underline"
+              className="truncate text-[13px] font-semibold text-blue-500 hover:underline"
             >
               바로가기
             </Link>


### PR DESCRIPTION
## 작업 내용

- 기업 상세 페이지 반응형 레이아웃 보정
- 데스크탑 UI는 유지하고 모바일/중간 해상도에서만 상세/분석 섹션 배치 정리
- 상단 상세 정보 영역이 모든 breakpoint에서 안정적으로 먼저 노출되도록 폭/정렬 보정
- 기업 메타 카드(사원 수/주소지/설립연도/홈페이지) 모바일 2x2 그리드 적용
- 긴 주소/메타 텍스트 overflow 완화
- 기업 상세에 누락된 `포폴 전략 생성하러가기` FAB 렌더링 추가 및 모바일 safe-area 여백 보정

## 리뷰 필요

- 모바일/중간 해상도에서 상단 정보 영역과 분석 섹션 전환이 자연스러운지 확인 부탁드립니다.
- 기업 메타 카드 2x2 배치와 FAB 위치/safe-area 간격이 의도대로 보이는지 확인 부탁드립니다.

close #122 