### PR TITLE
fix: 포폴 전략/면접 질문 상세 조회 생성 중 응답 처리 수정

### DIFF
--- a/src/features/interview/actions.ts
+++ b/src/features/interview/actions.ts
@@ -19,9 +19,23 @@ export async function getInterviewList(): Promise<ApiResponse<GetInterviewListRe
 export async function getInterview(
   interviewStrategyId: number,
 ): Promise<ApiResponse<GetInterviewResponse>> {
-  return await privateFetch<GetInterviewResponse>(`/api/v1/interviews/${interviewStrategyId}`, {
-    cache: 'no-store',
-  });
+  try {
+    return await privateFetch<GetInterviewResponse>(`/api/v1/interviews/${interviewStrategyId}`, {
+      cache: 'no-store',
+    });
+  } catch (error) {
+    const code = getFailureCode(error);
+
+    if (code === 'INTERVIEW_STRATEGY_RESULT_NOT_READY') {
+      return {
+        success: false,
+        code,
+        message: getFailureMessage(error),
+      } as ApiResponse<GetInterviewResponse>;
+    }
+
+    throw error;
+  }
 }
 
 // 면접 질문 생성
@@ -48,4 +62,31 @@ export async function getInterviewAvailability(): Promise<
   return await privateFetch<GetInterviewAvailablityResponse>(
     '/api/v1/interview-strategies/availability',
   );
+}
+
+type ApiFailureLike = {
+  response?: {
+    bodyJson?: {
+      code?: string;
+      message?: string;
+    };
+  };
+};
+
+function getFailureCode(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null) {
+    return (error as ApiFailureLike).response?.bodyJson?.code;
+  }
+  return undefined;
+}
+
+function getFailureMessage(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    return (
+      (error as ApiFailureLike).response?.bodyJson?.message ??
+      (error as { message?: string }).message ??
+      '알 수 없는 오류가 발생했습니다.'
+    );
+  }
+  return '알 수 없는 오류가 발생했습니다.';
 }

--- a/src/features/strategy/actions.ts
+++ b/src/features/strategy/actions.ts
@@ -29,12 +29,27 @@ export async function createStrategy(
 export async function getStrategyDetail(
   strategyId: number,
 ): Promise<ApiResponse<GetStrategyDetailResponse>> {
-  return await privateFetch<GetStrategyDetailResponse>(
-    `/api/v1/portfolio-strategies/${strategyId}`,
-    {
-      cache: 'no-store',
-    },
-  );
+  try {
+    return await privateFetch<GetStrategyDetailResponse>(
+      `/api/v1/portfolio-strategies/${strategyId}`,
+      {
+        cache: 'no-store',
+      },
+    );
+  } catch (error) {
+    const code = getFailureCode(error);
+    const message = getFailureMessage(error);
+
+    if (code === 'PORTFOLIO_STRATEGY_RESULT_NOT_READY') {
+      return {
+        success: false,
+        code,
+        message,
+      } as ApiResponse<GetStrategyDetailResponse>;
+    }
+
+    throw error;
+  }
 }
 
 // 포폴 전략 삭제
@@ -49,4 +64,31 @@ export async function getStrategyAvailability(): Promise<
   ApiResponse<GetStrategyAvailablityResponse>
 > {
   return await privateFetch<GetStrategyAvailablityResponse>('/api/v1/strategies/availability');
+}
+
+type ApiFailureLike = {
+  response?: {
+    bodyJson?: {
+      code?: string;
+      message?: string;
+    };
+  };
+};
+
+function getFailureCode(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null) {
+    return (error as ApiFailureLike).response?.bodyJson?.code;
+  }
+  return undefined;
+}
+
+function getFailureMessage(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    return (
+      (error as ApiFailureLike).response?.bodyJson?.message ??
+      (error as { message?: string }).message ??
+      '알 수 없는 오류가 발생했습니다.'
+    );
+  }
+  return '알 수 없는 오류가 발생했습니다.';
 }


### PR DESCRIPTION
## 작업 내용

- 포폴 전략 상세 조회에서 생성 중 응답 코드(`PORTFOLIO_STRATEGY_RESULT_NOT_READY`)를 예외적으로 처리하도록 수정
- 면접 질문 상세 조회에서 생성 중 응답 코드(`INTERVIEW_STRATEGY_RESULT_NOT_READY`)를 예외적으로 처리하도록 수정
- 생성 중 상태와 실제 오류를 구분하도록 상세 조회 로직 정리

## 리뷰 필요

- 1. 포폴 전략/면접 질문 첫 생성 직후 상세페이지에서 생성 중 UI가 정상적으로 유지되는지 확인 부탁드립니다.
- 2. 생성 중 상태 외 실제 오류가 발생했을 때 기존 에러 처리 흐름에 영향이 없는지 확인 부탁드립니다.

close #164