### PR TITLE
fix: 로컬 빌드 시 standalone 옵션 제거

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,8 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  output: 'standalone',
+  output: process.env.CI ? 'standalone' : undefined,
+
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## 작업 내용

- 로컬 빌드 시 standalone 옵션으로 인한 오류 발생 -> 로컬 빌드 시 standalone 옵션 제외

## 리뷰 필요

x

close #168 
