### PR TITLE
fix: 경험 상세 모달 잘림 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
+    "tailwind-scrollbar-hide": "^4.0.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tailwind-scrollbar-hide:
+        specifier: ^4.0.0
+        version: 4.0.0(tailwindcss@4.2.1)
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -3527,6 +3530,11 @@ packages:
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwind-scrollbar-hide@4.0.0:
+    resolution: {integrity: sha512-gobtvVcThB2Dxhy0EeYSS1RKQJ5baDFkamkhwBvzvevwX6L4XQfpZ3me9s25Ss1ecFVT5jPYJ50n+7xTBJG9WQ==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20'
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -7543,6 +7551,10 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
+
+  tailwind-scrollbar-hide@4.0.0(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
 
   tailwindcss@4.2.1: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
-@plugin "tailwind-scrollbar-hide";
+@import 'tailwind-scrollbar-hide/v4';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@plugin "tailwind-scrollbar-hide";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/features/experience/components/sections/ExperienceSection.tsx
+++ b/src/features/experience/components/sections/ExperienceSection.tsx
@@ -11,6 +11,8 @@ import { useGetExperienceList } from '@/features/experience/queries';
 import { useFiles } from '@/features/file/queries';
 import { useExperienceExtractionStore } from '@/features/experience/stores/useExperienceExtractionStore';
 import { getExtractedExperience } from '@/features/experience/actions';
+import ExperienceDetailDialog from '@/features/strategy/components/ui/ExperienceDetailDialog';
+import { useExperienceDetailDialog } from '@/features/experience/stores/useExperienceDetailDialog';
 
 export default function ExperienceSection() {
   const { data: filesData } = useFiles();
@@ -19,6 +21,8 @@ export default function ExperienceSection() {
   const experienceList = experienceData?.contents ?? [];
 
   const [clientExperienceList, setClientExperienceList] = useState<Experience[]>(experienceList);
+
+  const { experience, closeDialog } = useExperienceDetailDialog();
 
   const completedExtractionIds = useExperienceExtractionStore(
     (state) => state.completedExtractionIds,
@@ -124,6 +128,7 @@ export default function ExperienceSection() {
         )}
       </div>
       <ExperienceExtractDialog files={files} />
+      <ExperienceDetailDialog experience={experience} onClose={closeDialog} />
     </>
   );
 }

--- a/src/features/experience/components/ui/ExperienceCardForm.tsx
+++ b/src/features/experience/components/ui/ExperienceCardForm.tsx
@@ -21,6 +21,7 @@ import { PencilIcon, SparklesIcon, Trash2Icon } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import ExperienceCancelDialog from '@/features/experience/components/ui/ExperienceCancelDialog';
+import { useExperienceDetailDialog } from '@/features/experience/stores/useExperienceDetailDialog';
 
 interface ExperienceCardFormProps {
   experience: Experience;
@@ -41,6 +42,7 @@ export default function ExperienceCardForm({
 }: ExperienceCardFormProps) {
   const [isEditing, setIsEditing] = useState(isNew);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const { openDialog, setExperience } = useExperienceDetailDialog();
 
   const { mutate: createExperience, isPending: isCreating } = useCreateExperience();
   const { mutate: updateExperience, isPending: isUpdating } = useUpdateExperience();
@@ -280,7 +282,13 @@ export default function ExperienceCardForm({
 
   return (
     /* 조회 용 */
-    <div className="flex items-center justify-between gap-3 px-5 py-3.5">
+    <div
+      className="flex items-center justify-between gap-3 px-5 py-3.5 cursor-pointer"
+      onClick={() => {
+        setExperience(experience);
+        openDialog();
+      }}
+    >
       <div className="flex flex-1 items-center gap-2.5 overflow-hidden">
         {/* 경험 유형 */}
         <span
@@ -313,7 +321,10 @@ export default function ExperienceCardForm({
           type="button"
           variant="ghost"
           size="icon"
-          onClick={() => setIsEditing(true)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsEditing(true);
+          }}
           aria-label="수정"
           className="text-gray-400 hover:bg-gray-100 hover:text-gray-600"
         >
@@ -323,7 +334,10 @@ export default function ExperienceCardForm({
           type="button"
           variant="ghost"
           size="icon"
-          onClick={() => onDeleteDialogOpen(true)}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteDialogOpen(true);
+          }}
           aria-label="삭제"
           className="text-gray-400 hover:bg-red-50 hover:text-red-500"
         >

--- a/src/features/experience/stores/useExperienceDetailDialog.ts
+++ b/src/features/experience/stores/useExperienceDetailDialog.ts
@@ -1,0 +1,18 @@
+import { Experience } from '@/features/experience/types';
+import { create } from 'zustand';
+
+interface ExperienceDetailDialogStore {
+  experience: Experience | null;
+  isDialogOpen: boolean;
+  setExperience: (experience: Experience) => void;
+  openDialog: () => void;
+  closeDialog: () => void;
+}
+
+export const useExperienceDetailDialog = create<ExperienceDetailDialogStore>()((set) => ({
+  experience: null,
+  isDialogOpen: false,
+  setExperience: (exp) => set({ experience: exp }),
+  openDialog: () => set({ isDialogOpen: true }),
+  closeDialog: () => set({ experience: null, isDialogOpen: false }),
+}));

--- a/src/features/strategy/components/ui/ExperienceDetailDialog.tsx
+++ b/src/features/strategy/components/ui/ExperienceDetailDialog.tsx
@@ -1,9 +1,9 @@
 import { Calendar, X } from 'lucide-react';
 import type { Experience } from '@/features/experience/types';
 import { EXPERIENCE_LABEL_MAP } from '@/features/experience/constants/experienceOptions';
-import { formatHistoryDate } from '@/shared/utils/formatHistoryDate';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/components/ui/dialog';
 import { EXP_BADGE_CHECKED } from '@/features/experience/constants/experienceBadgeStyles';
+import { toDisplayDate } from '@/features/experience/utils/toDisplayDate';
 
 interface ExperienceDetailDialogProps {
   experience: Experience | null;
@@ -19,7 +19,7 @@ export default function ExperienceDetailDialog({
       <DialogContent
         aria-describedby={undefined}
         showCloseButton={false}
-        className="max-h-[80svh] max-w-125 gap-0 overflow-hidden p-0 max-md:top-auto max-md:left-1/2 max-md:bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] max-md:w-[calc(100%-1rem)] max-md:max-w-none max-md:-translate-x-1/2 max-md:translate-y-0 max-md:rounded-2xl max-md:max-h-[68dvh]"
+        className="flex flex-col max-h-[80svh] max-w-125 gap-0 overflow-hidden p-0 max-md:top-auto max-md:left-1/2 max-md:bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] max-md:w-[calc(100%-1rem)] max-md:max-w-none max-md:-translate-x-1/2 max-md:translate-y-0 max-md:rounded-2xl max-md:max-h-[68dvh]"
       >
         {experience && (
           <>
@@ -41,10 +41,8 @@ export default function ExperienceDetailDialog({
                   <div className="mt-1.5 flex items-center gap-1.5">
                     <Calendar className="h-3.5 w-3.5 shrink-0 text-gray-400" />
                     <span className="text-[13px] leading-none text-gray-400">
-                      {formatHistoryDate(experience.startDate)}
-                      {experience.endDate
-                        ? ` – ${formatHistoryDate(experience.endDate)}`
-                        : ' – 현재'}
+                      {toDisplayDate(experience.startDate)}
+                      {experience.endDate ? ` – ${toDisplayDate(experience.endDate)}` : ' – 현재'}
                     </span>
                   </div>
                 </div>
@@ -60,9 +58,9 @@ export default function ExperienceDetailDialog({
               </div>
             </DialogHeader>
 
-            <div className="min-h-0 overflow-y-auto px-6 py-4 max-md:px-4 max-md:py-3.5">
+            <div className="min-h-0 flex-1 scrollbar-hide overflow-y-auto px-6 py-4 max-md:px-4 max-md:py-3.5">
               <div className="rounded-lg border border-gray-100 bg-gray-50 px-3.5 py-3">
-                <p className="whitespace-pre-wrap wrap-break-word text-[14px] leading-[1.65] text-gray-700">
+                <p className="whitespace-pre-wrap break-words text-[14px] leading-[1.65] text-gray-700">
                   {experience.experienceContent ?? '경험 내용이 없습니다.'}
                 </p>
               </div>


### PR DESCRIPTION
## 작업 내용

- 모바일 환경에서 경험 상세 모달 내의 경험 내용이 길 경우, 텍스트가 잘려 보이지 않는 현상 수정
- 내 경험 페이지에서 경험 상세 모달 연결
- `scrollbar-hide` 플러그인 추가

## 리뷰 필요

1. pnpm install 필요합니다
2. 모바일 환경에서 잘리지 않고 잘 표기되는지 확인 필요
3. 내 경험 페이지에서 경험 상세 모달 연결이 적절한지 확인 필요

close #175 
