### PR TITLE
feat: ai 요청 상태 유지 구현

### DIFF
--- a/src/features/experience/components/sections/ExperienceExtractionPollingListener.tsx
+++ b/src/features/experience/components/sections/ExperienceExtractionPollingListener.tsx
@@ -145,9 +145,19 @@ export default function ExperienceExtractionPollingListener() {
 
     return () => {
       cancelled = true;
-      window.clearTimeout(timeoutId);
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
     };
-  }, [processingRequestIds]);
+  }, [
+    processingRequestIds,
+    markRequestFailed,
+    markRequestCompleted,
+    removeBatch,
+    removeRequest,
+    addCompletedExtractionIds,
+    router,
+  ]);
 
   return null;
 }

--- a/src/features/experience/components/sections/ExperienceExtractionPollingListener.tsx
+++ b/src/features/experience/components/sections/ExperienceExtractionPollingListener.tsx
@@ -29,7 +29,6 @@ export default function ExperienceExtractionPollingListener() {
     [requestOrder, requests],
   );
 
-  // 요청 ID / 재시도 횟수
   const requestRetryCountsRef = useRef<Map<number, number>>(new Map());
 
   useEffect(() => {
@@ -43,11 +42,11 @@ export default function ExperienceExtractionPollingListener() {
     }
 
     let cancelled = false;
+    let timeoutId: number;
 
     const poll = async () => {
       if (cancelled) return;
 
-      // allSettled로 Promise 순서 보장됨
       const statusResults = await Promise.allSettled(
         processingRequestIds.map(async (id) => {
           const res = await getGenerationStatus({ id, type: 'EXTRACT_EXPERIENCE' });
@@ -61,7 +60,7 @@ export default function ExperienceExtractionPollingListener() {
         const settled = statusResults[i];
         const id = processingRequestIds[i];
 
-        // 비동기 작업 실패 (네트워크 오류 및 시간 초과)
+        // 1. 비동기 작업 자체 실패 (네트워크 오류, 시간 초과 등)
         if (settled.status === 'rejected') {
           const retryCount = (requestRetryCountsRef.current.get(id) ?? 0) + 1;
           requestRetryCountsRef.current.set(id, retryCount);
@@ -82,7 +81,7 @@ export default function ExperienceExtractionPollingListener() {
 
         const { res } = settled.value;
 
-        // API 응답 결과: 실패 시
+        // 2. 서버가 내려준 구조화된 객체 처리: API 비즈니스 로직 상 실패 시
         if (!res.success) {
           const retryCount = (requestRetryCountsRef.current.get(id) ?? 0) + 1;
           requestRetryCountsRef.current.set(id, retryCount);
@@ -98,12 +97,10 @@ export default function ExperienceExtractionPollingListener() {
           continue;
         }
 
-        // 경험 추출 상태 조회 성공 시 (FAILED, PROCESSING, READY)
+        // 3. 경험 추출 상태 조회 성공 시 (FAILED, PROCESSING, READY)
         requestRetryCountsRef.current.delete(id);
-
         const { status, error } = res.data;
 
-        // FAILED
         if (status === 'FAILED') {
           console.error(`[경험 추출] 요청ID(${id}): ${error}`);
           markRequestFailed(id, error ?? '경험 추출에 실패했습니다.');
@@ -111,13 +108,11 @@ export default function ExperienceExtractionPollingListener() {
           continue;
         }
 
-        // READY가 되기 전까지 반복 폴링
         if (status !== 'READY') continue;
 
-        // READY
+        // READY 처리 로직
         markRequestCompleted(id);
 
-        // 같은 배치 작업에 있는 요청 id가 모두 완료되었는지 확인
         const { requests: latestRequests, batches } = useExperienceExtractionStore.getState();
 
         const completedBatchEntry = Object.entries(batches).find(([, batch]) =>
@@ -130,8 +125,6 @@ export default function ExperienceExtractionPollingListener() {
 
         removeBatch(batchId);
         batch.ids.forEach((expId) => removeRequest(expId));
-
-        // 완료된 추출 ID를 store에 저장 — 페이지에서 소비
         addCompletedExtractionIds(batch.ids);
 
         toast.success('경험 추출이 완료되었어요.', {
@@ -141,24 +134,20 @@ export default function ExperienceExtractionPollingListener() {
           },
         });
       }
+
+      if (!cancelled) {
+        timeoutId = window.setTimeout(poll, POLLING_INTERVAL_MS);
+      }
     };
 
-    poll();
-    const timer = setInterval(() => poll(), POLLING_INTERVAL_MS);
+    // 첫 폴링 실행
+    void poll();
 
     return () => {
       cancelled = true;
-      clearInterval(timer);
+      window.clearTimeout(timeoutId);
     };
-  }, [
-    processingRequestIds,
-    markRequestCompleted,
-    markRequestFailed,
-    removeBatch,
-    removeRequest,
-    addCompletedExtractionIds,
-    router,
-  ]);
+  }, [processingRequestIds]);
 
   return null;
 }

--- a/src/features/experience/components/sections/ExperienceSection.tsx
+++ b/src/features/experience/components/sections/ExperienceSection.tsx
@@ -27,17 +27,16 @@ export default function ExperienceSection() {
   const completedExtractionIds = useExperienceExtractionStore(
     (state) => state.completedExtractionIds,
   );
-  const removeCompletedExtractionId = useExperienceExtractionStore(
-    (state) => state.removeCompletedExtractionId,
+  const removeCompletedExtractionIds = useExperienceExtractionStore(
+    (state) => state.removeCompletedExtractionIds,
   );
 
-  // 완료된 추출 ID 감지 → 상세 조회 → 카드 추가
-  // 조회 성공한 ID만 소비 (원자적 처리): 실패한 ID는 store에 유지되어 재시도 가능
   useEffect(() => {
     if (completedExtractionIds.length === 0) return;
 
-    // 현재 사이클의 ID를 스냅샷으로 캡처
     const idsToFetch = [...completedExtractionIds];
+
+    removeCompletedExtractionIds(idsToFetch);
 
     const fetchAndAppend = async () => {
       const results = await Promise.allSettled(
@@ -48,10 +47,9 @@ export default function ExperienceSection() {
       let tempIdSeed = Date.now();
 
       for (const result of results) {
-        if (result.status !== 'fulfilled' || !result.value.res.success) continue;
-
-        // 조회 성공 시에만 해당 ID를 store에서 제거
-        removeCompletedExtractionId(result.value.id);
+        if (result.status !== 'fulfilled' || !result.value.res.success) {
+          continue;
+        }
 
         result.value.res.data.contents.forEach((draft) => {
           newExperiences.push({ ...draft, experienceId: -tempIdSeed++, isAiGenerated: true });
@@ -64,7 +62,7 @@ export default function ExperienceSection() {
     };
 
     fetchAndAppend();
-  }, [completedExtractionIds, removeCompletedExtractionId]);
+  }, [completedExtractionIds, removeCompletedExtractionIds]);
 
   // 새로운 빈 카드 추가
   const handleAddCard = () => {

--- a/src/features/experience/stores/useExperienceExtractionStore.tsx
+++ b/src/features/experience/stores/useExperienceExtractionStore.tsx
@@ -17,6 +17,7 @@ export type ExperienceExtractionStore = GenerationStore & {
   completedExtractionIds: number[];
   addCompletedExtractionIds: (ids: number[]) => void;
   removeCompletedExtractionId: (id: number) => void;
+  removeCompletedExtractionIds: (ids: number[]) => void;
 };
 
 export const useExperienceExtractionStore = create<ExperienceExtractionStore>()(
@@ -53,12 +54,23 @@ export const useExperienceExtractionStore = create<ExperienceExtractionStore>()(
         set((state) => ({
           completedExtractionIds: state.completedExtractionIds.filter((cid) => cid !== id),
         })),
+
+      removeCompletedExtractionIds: (idsToRemove) =>
+        set((state) => ({
+          completedExtractionIds: state.completedExtractionIds.filter(
+            (cid) => !idsToRemove.includes(cid),
+          ),
+        })),
     }),
     {
-      name: 'experience-extraction-ids',
+      name: 'experience-extraction-state',
       partialize: (state) => ({
-        ...state,
-        submitLoading: false,
+        generationStatus: state.generationStatus,
+        requests: state.requests,
+        requestOrder: state.requestOrder,
+        batches: state.batches,
+        batchOrder: state.batchOrder,
+        completedExtractionIds: state.completedExtractionIds,
       }),
     },
   ),

--- a/src/features/experience/stores/useExperienceExtractionStore.tsx
+++ b/src/features/experience/stores/useExperienceExtractionStore.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { createGenerationStore, type GenerationStore } from '@/shared/stores/createGenerationStore';
 
 type BatchState = {
@@ -18,37 +19,47 @@ export type ExperienceExtractionStore = GenerationStore & {
   removeCompletedExtractionId: (id: number) => void;
 };
 
-export const useExperienceExtractionStore = create<ExperienceExtractionStore>((set, get, api) => ({
-  ...createGenerationStore('EXTRACT_EXPERIENCE')(set, get, api),
+export const useExperienceExtractionStore = create<ExperienceExtractionStore>()(
+  persist(
+    (set, get, api) => ({
+      ...createGenerationStore('EXTRACT_EXPERIENCE')(set, get, api),
+      batches: {},
+      batchOrder: [],
 
-  batches: {},
-  batchOrder: [],
+      addBatch: (batchId, ids) =>
+        set((state) => ({
+          batches: { ...state.batches, [batchId]: { ids } },
+          batchOrder: [...state.batchOrder, batchId],
+        })),
 
-  addBatch: (batchId, ids) =>
-    set((state) => ({
-      batches: { ...state.batches, [batchId]: { ids } },
-      batchOrder: [...state.batchOrder, batchId],
-    })),
+      removeBatch: (batchId) =>
+        set((state) => {
+          const next = { ...state.batches };
+          delete next[batchId];
+          return {
+            batches: next,
+            batchOrder: state.batchOrder.filter((id) => id !== batchId),
+          };
+        }),
 
-  removeBatch: (batchId) =>
-    set((state) => {
-      const next = { ...state.batches };
-      delete next[batchId];
-      return {
-        batches: next,
-        batchOrder: state.batchOrder.filter((id) => id !== batchId),
-      };
+      completedExtractionIds: [],
+
+      addCompletedExtractionIds: (ids) =>
+        set((state) => ({
+          completedExtractionIds: [...state.completedExtractionIds, ...ids],
+        })),
+
+      removeCompletedExtractionId: (id) =>
+        set((state) => ({
+          completedExtractionIds: state.completedExtractionIds.filter((cid) => cid !== id),
+        })),
     }),
-
-  completedExtractionIds: [],
-
-  addCompletedExtractionIds: (ids) =>
-    set((state) => ({
-      completedExtractionIds: [...state.completedExtractionIds, ...ids],
-    })),
-
-  removeCompletedExtractionId: (id) =>
-    set((state) => ({
-      completedExtractionIds: state.completedExtractionIds.filter((cid) => cid !== id),
-    })),
-}));
+    {
+      name: 'experience-extraction-ids',
+      partialize: (state) => ({
+        ...state,
+        submitLoading: false,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## 작업 내용

- zustand persist를 사용하여 localstorage에 경험 추출 요청 id 저장 및 유지
- setInterval -> setTimeout으로 변경하여 네트워크 지연 시 요청 중첩 방지
  - **getGenerationStatus 가 완료된 뒤**에 2초 뒤에 다음 폴링 로직 수행

## 리뷰 필요

1. 경험 추출 중에 새로고침, 세션 종료 후 재접속 하더라도 제대로 유지되는지 확인 필요
2. 변경된 로직이 적절한지 확인 필요

close #178 
