### PR TITLE
fix: 보호 라우트 수정

### DIFF
--- a/src/shared/utils/isProtectedRoute.ts
+++ b/src/shared/utils/isProtectedRoute.ts
@@ -1,5 +1,5 @@
 export const PROTECTED_ROUTES = {
-  PREFIXES: ['/my'],
+  PREFIXES: ['/my', '/strategy', '/interview'],
   PATTERNS: [/^\/strategy\/result\/\d+$/, /^\/interview\/result\/\d+$/],
 } as const;
 
@@ -7,8 +7,9 @@ export const isProtectedRoute = (pathname: string): boolean => {
   // Prefix 검사
   const isPrefixMatch = PROTECTED_ROUTES.PREFIXES.some((prefix) => pathname.startsWith(prefix));
   if (isPrefixMatch) return true;
+  return false;
 
   // 정규식 패턴 검사
-  const isPatternMatch = PROTECTED_ROUTES.PATTERNS.some((pattern) => pattern.test(pathname));
-  return isPatternMatch;
+  // const isPatternMatch = PROTECTED_ROUTES.PATTERNS.some((pattern) => pattern.test(pathname));
+  // return isPatternMatch;
 };


### PR DESCRIPTION
## 작업 내용

- 포폴 전략, 면접 질문 페이지 보호 라우트에 추가
- `/strategy`, `/interview`로 시작하는 라우트를 포함하도록 변경되어, 기존에 정규식 패턴 검사는 주석 처리

## 리뷰 필요

1. 보호 라우트가 적절하게 설정되었는지 확인 필요.
2. 테스트 시 `proxy.ts`에서 해당 부분 주석 처리 필요 (#177 에서 수정하였으나, 아직 머지되지 않아 수정하지 않음)
  ```tsx
  // if (process.env.NODE_ENV === 'development') {
  //   return NextResponse.next();
  // }
```

close #181 
