### PR TITLE
refactor: 캐싱 로직 적절히 수정

### DIFF
--- a/src/features/bookmark/queries.ts
+++ b/src/features/bookmark/queries.ts
@@ -29,8 +29,8 @@ export function bookmarkQueryOptions() {
 
       return result.data ?? createEmptyBookmarkResponse();
     },
-    staleTime: Infinity,
-    gcTime: 1000 * 60 * 30,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   };
@@ -59,8 +59,8 @@ export function useBookmarkStatus(enabled = true) {
 
       return reconcileBookmarkStatusMap(previousStatusMap, bookmarks.content);
     },
-    staleTime: Infinity,
-    gcTime: 1000 * 60 * 30,
+    staleTime: 5 * 60 ** 1000,
+    gcTime: 30 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/src/features/bookmark/queries.ts
+++ b/src/features/bookmark/queries.ts
@@ -59,7 +59,7 @@ export function useBookmarkStatus(enabled = true) {
 
       return reconcileBookmarkStatusMap(previousStatusMap, bookmarks.content);
     },
-    staleTime: 5 * 60 ** 1000,
+    staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -9,6 +9,6 @@ export async function getCompanyDetail(
   companyId: number,
 ): Promise<ApiResponse<GetCompanyDetailResponse>> {
   return await publicFetch<GetCompanyDetailResponse>(`/api/v1/companies/${companyId}`, {
-    next: { revalidate: 300, tags: ['company', `company-detail-${companyId}`] },
+    next: { revalidate: 5 * 60, tags: ['company', `company-detail-${companyId}`] },
   });
 }

--- a/src/features/company/queries.ts
+++ b/src/features/company/queries.ts
@@ -20,5 +20,6 @@ export const getCompanyDetailQueryOptions = (companyId: number) => ({
     }
     return result.data;
   },
-  staleTime: 60 * 1000,
+  staleTime: 5 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
 });

--- a/src/features/experience/queries.ts
+++ b/src/features/experience/queries.ts
@@ -27,7 +27,7 @@ export const experienceListQueryOptions = () => ({
     }
     return result.data;
   },
-  staleTime: 60 * 1000,
+  staleTime: 10 * 60 * 1000,
 });
 
 export const experienceQueryOptions = (experienceId: number) => ({
@@ -39,7 +39,8 @@ export const experienceQueryOptions = (experienceId: number) => ({
     }
     return result.data;
   },
-  staleTime: 60 * 1000,
+  staleTime: 10 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
 });
 
 // 경험 목록 조회

--- a/src/features/experience/queries.ts
+++ b/src/features/experience/queries.ts
@@ -28,6 +28,7 @@ export const experienceListQueryOptions = () => ({
     return result.data;
   },
   staleTime: 10 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
 });
 
 export const experienceQueryOptions = (experienceId: number) => ({

--- a/src/features/file/queries.ts
+++ b/src/features/file/queries.ts
@@ -17,8 +17,8 @@ export const fileQueryOptions = () => ({
 
     return result.data;
   },
-  // 1분
-  staleTime: 60 * 1000,
+  staleTime: 10 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
 });
 
 // 파일 목록 조회

--- a/src/features/industry/actions.ts
+++ b/src/features/industry/actions.ts
@@ -1,22 +1,24 @@
 'use server';
 
-import { privateFetch, publicFetch } from '@/shared/api/httpClient';
+import { publicFetch } from '@/shared/api/httpClient';
 import { ApiResponse } from '@/shared/types/api';
 import { GetIndustryAnalysisResponse, GetIndustryListResponse } from '@/features/industry/types';
 
 // 산업 목록 조회
 export async function getIndustryList(): Promise<ApiResponse<GetIndustryListResponse>> {
-  return await publicFetch<GetIndustryListResponse>(`/api/v1/industries`);
+  return await publicFetch<GetIndustryListResponse>(`/api/v1/industries`, {
+    next: { revalidate: 24 * 60 * 60, tags: ['industryList'] },
+  });
 }
 
 // 산업 분석 조회
 export async function getIndustryAnalysis(
   industryId: number,
 ): Promise<ApiResponse<GetIndustryAnalysisResponse>> {
-  return await privateFetch<GetIndustryAnalysisResponse>(
+  return await publicFetch<GetIndustryAnalysisResponse>(
     `/api/v1/industries/${industryId}/reports`,
     {
-      next: { revalidate: 300, tags: ['industry', `industry-detail-${industryId}`] },
+      next: { revalidate: 24 * 60 * 60, tags: ['industry', `industry-detail-${industryId}`] },
     },
   );
 }

--- a/src/features/industry/queries.ts
+++ b/src/features/industry/queries.ts
@@ -27,6 +27,7 @@ export const getIndustryListQueryOptions = () => ({
     return result.data;
   },
   staleTime: 24 * 60 * 60 * 1000,
+  gcTime: 24 * 60 * 60 * 1000,
 });
 
 export const getIndustryAnalysisQueryOptions = (industryId: number) => ({
@@ -38,5 +39,6 @@ export const getIndustryAnalysisQueryOptions = (industryId: number) => ({
     }
     return result.data;
   },
-  staleTime: 60 * 1000,
+  staleTime: 5 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
 });

--- a/src/features/industry/queries.ts
+++ b/src/features/industry/queries.ts
@@ -39,6 +39,6 @@ export const getIndustryAnalysisQueryOptions = (industryId: number) => ({
     }
     return result.data;
   },
-  staleTime: 5 * 60 * 1000,
-  gcTime: 30 * 60 * 1000,
+  staleTime: 24 * 60 * 60 * 1000,
+  gcTime: 24 * 60 * 60 * 1000,
 });

--- a/src/features/interview/queries.ts
+++ b/src/features/interview/queries.ts
@@ -30,7 +30,8 @@ export const getInterviewListQueryOptions = () => ({
     }
     return result.data;
   },
-  staleTime: 60 * 1000,
+  staleTime: 5 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
 });
 
 // 면접 질문 단건 조회
@@ -47,7 +48,8 @@ export const getInterviewQueryOptions = (interviewStrategyId: number) => ({
     }
     return result.data;
   },
-  staleTime: 60 * 1000,
+  staleTime: 60 * 60 * 1000,
+  gcTime: 60 * 60 * 1000,
   enabled: !!interviewStrategyId,
   retry: false,
 });

--- a/src/features/recruitment/actions.ts
+++ b/src/features/recruitment/actions.ts
@@ -22,7 +22,9 @@ export async function getRecruitments(
   if (typeof params.size === 'number') searchParams.set('size', String(params.size));
   const query = searchParams.toString();
 
-  return await publicFetch<GetRecruitmentsResponse>(`/api/v1/posts${query ? `?${query}` : ''}`);
+  return await publicFetch<GetRecruitmentsResponse>(`/api/v1/posts${query ? `?${query}` : ''}`, {
+    next: { revalidate: 60, tags: ['recruitmentList'] },
+  });
 }
 
 // 공고 상세 조회


### PR DESCRIPTION
## 작업 내용

- `staleTime`과 next `revalidate` 시간 통일 및 적절히 시간 조절
- `gcTime` 미설정된 부분 추가 (기본적으로 5분이며, staleTime보다 같거나 길게 설정함)
- getIndustryAnalysis `privateFetch`로 되어있던 오류 수정

## 리뷰 필요

1. 북마크의 경우 기존에 Infinity로 되어있었지만, 다중 기기 접속 후 한 기기에서 변경 시에 다른 기기에서 반영이 되지 않을 수 있어 5분으로 설정하였습니다.
2. 시간 적절하게 설정되었는지 확인 필요

close #183 
