### PR TITLE
refactor: AuthProvider zustand로 마이그레이션

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ import StrategyGenerationPollingListener from '@/features/strategy/components/se
 import MobileMainBottomNav from '@/features/recruitment/components/ui/MobileMainBottomNav';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { cookies } from 'next/headers';
-import { AuthProvider } from '@/shared/provider/AuthProvider';
+import { AuthStoreProvider } from '@/shared/provider/AuthProvider';
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL ?? 'https://gonggomoon.com'),
@@ -62,16 +62,21 @@ export default async function RootLayout({
     <html lang="ko" className={`${pretendard.variable} ${pretendard.className}`}>
       <body>
         <QueryProvider>
-          <AuthProvider isLoggedIn={isLoggedIn}>
+          <AuthStoreProvider isLoggedIn={isLoggedIn}>
             <Header />
             {children}
-          </AuthProvider>
+          </AuthStoreProvider>
+
+          {/* Polling Listener */}
           <StrategyGenerationPollingListener />
           <InterviewGenerationPollingListener />
           <ExperienceExtractionPollingListener />
+
+          {/* Global UI */}
           <Toaster richColors position="top-right" />
           <LoginModal />
           <MobileMainBottomNav />
+
           <Suspense>
             <LoginModalTrigger />
           </Suspense>

--- a/src/features/auth/components/ui/ProfileMenu.tsx
+++ b/src/features/auth/components/ui/ProfileMenu.tsx
@@ -15,11 +15,11 @@ import { Button } from '@/shared/components/ui/button';
 import { useLogout } from '@/features/auth/queries';
 import { useUser } from '@/features/user/queries';
 import { useLoginModal } from '@/features/auth/stores/useLoginModal';
-import { useAuth } from '@/shared/provider/AuthProvider';
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 
 export default function ProfileMenu() {
-  const { isLoggedIn } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { data: user, isLoading, isError } = useUser({ enabled: isLoggedIn });
   const { mutate: logout, isPending } = useLogout();
   const { openDialog } = useLoginModal();

--- a/src/features/auth/queries.ts
+++ b/src/features/auth/queries.ts
@@ -2,7 +2,7 @@ import { logout } from '@/features/auth/actions';
 import { companyKeys } from '@/features/company/queries';
 import { industryKeys } from '@/features/industry/queries';
 import { recruitmentKeys } from '@/features/recruitment/queries';
-import { useAuth } from '@/shared/provider/AuthProvider';
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 import { isProtectedRoute } from '@/shared/utils/isProtectedRoute';
 import { Query, useMutation, useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'next/navigation';
@@ -12,8 +12,7 @@ export function useLogout() {
   const queryClient = useQueryClient();
   const pathname = usePathname();
   const router = useRouter();
-  const { setIsLoggedIn } = useAuth();
-
+  const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn);
   return useMutation({
     mutationFn: async () => {
       queryClient.removeQueries({

--- a/src/features/auth/stores/authStore.ts
+++ b/src/features/auth/stores/authStore.ts
@@ -1,0 +1,15 @@
+import { createStore } from 'zustand/vanilla';
+
+export type AuthState = {
+  isLoggedIn: boolean;
+  setIsLoggedIn: (value: boolean) => void;
+};
+
+export const createAuthStore = (initProps?: Partial<AuthState>) => {
+  return createStore<AuthState>()((set) => ({
+    isLoggedIn: initProps?.isLoggedIn ?? false,
+    setIsLoggedIn: (value) => set({ isLoggedIn: value }),
+  }));
+};
+
+export type AuthStore = ReturnType<typeof createAuthStore>;

--- a/src/features/bookmark/components/ui/BookmarkButton.tsx
+++ b/src/features/bookmark/components/ui/BookmarkButton.tsx
@@ -4,8 +4,7 @@ import type { MouseEvent } from 'react';
 import { Bookmark } from 'lucide-react';
 import { useLoginModal } from '@/features/auth/stores/useLoginModal';
 import { useBookmarkStatus, useGetBookmarks, useToggleBookmark } from '@/features/bookmark/queries';
-import { useAuth } from '@/shared/provider/AuthProvider';
-
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 interface BookmarkButtonProps {
   postId: number;
   isBookmarked: boolean;
@@ -19,7 +18,7 @@ export default function BookmarkButton({
   disabled = false,
   variant = 'default',
 }: BookmarkButtonProps) {
-  const { isLoggedIn } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { openDialog } = useLoginModal();
 
   const { data: bookmarkStatusMap } = useBookmarkStatus(isLoggedIn);

--- a/src/features/recruitment/components/ui/BookmarkSidebar.tsx
+++ b/src/features/recruitment/components/ui/BookmarkSidebar.tsx
@@ -5,8 +5,7 @@ import { Bookmark as BookmarkIcon, ChevronRight } from 'lucide-react';
 import { formatBookmarkDate } from '@/shared/utils/formatBookmarkDate';
 import { useGetBookmarks } from '@/features/bookmark/queries';
 import { cn } from '@/shared/lib/cn';
-import { useAuth } from '@/shared/provider/AuthProvider';
-
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 interface BookmarkSidebarProps {
   showHeader?: boolean;
   variant?: 'sidebar' | 'sheet';
@@ -16,7 +15,7 @@ export default function BookmarkSidebar({
   showHeader = true,
   variant = 'sidebar',
 }: BookmarkSidebarProps) {
-  const { isLoggedIn } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { data: bookmarks } = useGetBookmarks(isLoggedIn);
   const isSheet = variant === 'sheet';
 

--- a/src/features/recruitment/components/ui/RecruitmentDetailOverview.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentDetailOverview.tsx
@@ -8,14 +8,13 @@ import { formatDDay } from '@/shared/utils/formatDDay';
 import BookmarkButton from '@/features/bookmark/components/ui/BookmarkButton';
 import { DDAY_VARIANT_CLASS } from '@/features/recruitment/constants/dDayVariant';
 import { useGetBookmarks } from '@/features/bookmark/queries';
-import { useAuth } from '@/shared/provider/AuthProvider';
-
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 interface RecruitmentDetailOverviewProps {
   recruitment: RecruitmentDetail;
 }
 
 export default function RecruitmentDetailOverview({ recruitment }: RecruitmentDetailOverviewProps) {
-  const { isLoggedIn } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { data: bookmarks } = useGetBookmarks(isLoggedIn);
 
   const isBookmarked = (bookmarks?.content ?? []).some(

--- a/src/features/recruitment/components/ui/RecruitmentList.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentList.tsx
@@ -4,14 +4,13 @@ import { useMemo } from 'react';
 import RecruitmentListItem from '@/features/recruitment/components/ui/RecruitmentListItem';
 import type { Recruitment } from '@/features/recruitment/types';
 import { useGetBookmarks } from '@/features/bookmark/queries';
-import { useAuth } from '@/shared/provider/AuthProvider';
-
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 interface RecruitmentListProps {
   recruitments: Recruitment[];
 }
 
 export default function RecruitmentList({ recruitments }: RecruitmentListProps) {
-  const { isLoggedIn } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { data: bookmarks } = useGetBookmarks(isLoggedIn);
 
   const bookmarkedPostIds = useMemo(

--- a/src/features/recruitment/components/ui/RecruitmentRequestAction.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentRequestAction.tsx
@@ -6,10 +6,9 @@ import { toast } from 'sonner';
 import FloatingActionButton from '@/shared/components/ui/FloatingActionButton';
 import RecruitmentRequestDialog from '@/features/recruitment/components/ui/RecruitmentRequestDialog';
 import { useGetRecruitmentPlatforms, useRequestRecruitment } from '@/features/recruitment/queries';
-import { useAuth } from '@/shared/provider/AuthProvider';
-
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 export default function RecruitmentRequestAction() {
-  const { isLoggedIn } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const [isOpen, setIsOpen] = useState(false);
   const [dialogKey, setDialogKey] = useState(0);
 

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -2,7 +2,7 @@ import { companyKeys } from '@/features/company/queries';
 import { industryKeys } from '@/features/industry/queries';
 import { recruitmentKeys } from '@/features/recruitment/queries';
 import { getUser, deleteUser } from '@/features/user/actions';
-import { useAuth } from '@/shared/provider/AuthProvider';
+import { useAuthStore } from '@/shared/provider/AuthProvider';
 import { Query, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const userQueryOptions = () => ({
@@ -28,8 +28,7 @@ export function useUser(options?: { enabled?: boolean }) {
 // 회원 탈퇴
 export function useDeleteUser() {
   const queryClient = useQueryClient();
-  const { setIsLoggedIn } = useAuth();
-
+  const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn);
   return useMutation({
     mutationFn: () => deleteUser(),
     onSuccess: () => {

--- a/src/shared/provider/AuthProvider.tsx
+++ b/src/shared/provider/AuthProvider.tsx
@@ -1,37 +1,39 @@
-// src/shared/provider/AuthProvider.tsx
 'use client';
 
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useEffect, useRef } from 'react';
+import { useStore } from 'zustand';
+import { createAuthStore, type AuthStore, type AuthState } from '@/features/auth/stores/authStore';
 
-type AuthContextType = {
-  isLoggedIn: boolean;
-  setIsLoggedIn: (value: boolean) => void;
-};
+export const AuthStoreContext = createContext<AuthStore | null>(null);
 
-// 변경 함수도 함께 Context에 담습니다.
-const AuthContext = createContext<AuthContextType>({
-  isLoggedIn: false,
-  setIsLoggedIn: () => {},
-});
-
-export function AuthProvider({
-  isLoggedIn: initialIsLoggedIn,
+export function AuthStoreProvider({
   children,
+  isLoggedIn,
 }: {
-  isLoggedIn: boolean;
   children: React.ReactNode;
+  isLoggedIn: boolean;
 }) {
-  // 서버에서 넘겨받은 초기값으로 useState 세팅
-  const [isLoggedIn, setIsLoggedIn] = useState(initialIsLoggedIn);
+  const storeRef = useRef<AuthStore>(null);
 
-  // Next.js 라우터 이동 등으로 서버 초기값이 변경될 때 동기화 (안전장치)
+  if (!storeRef.current) {
+    storeRef.current = createAuthStore({ isLoggedIn });
+  }
+
   useEffect(() => {
-    setIsLoggedIn(initialIsLoggedIn);
-  }, [initialIsLoggedIn]);
+    if (storeRef.current) {
+      storeRef.current.setState({ isLoggedIn });
+    }
+  }, [isLoggedIn]);
 
-  return (
-    <AuthContext.Provider value={{ isLoggedIn, setIsLoggedIn }}>{children}</AuthContext.Provider>
-  );
+  return <AuthStoreContext.Provider value={storeRef.current}>{children}</AuthStoreContext.Provider>;
 }
 
-export const useAuth = () => useContext(AuthContext);
+export function useAuthStore<T>(selector: (state: AuthState) => T): T {
+  const authStoreContext = useContext(AuthStoreContext);
+
+  if (!authStoreContext) {
+    throw new Error(`useAuthStore는 AuthStoreProvider 안에서 사용되어야 합니다.`);
+  }
+
+  return useStore(authStoreContext, selector);
+}


### PR DESCRIPTION
## 작업 내용

- context api만으로 구현했던 AuthProvider 로직을 zustand + context api로 마이그레이션
- 현재 zustand와 context api를 결합한 형태로 리팩토링 되었습니다.
- https://zustand.docs.pmnd.rs/learn/guides/nextjs 문서를 참고해서 구현하였습니다.
- 위의 공식문서에서도, 서버 단에서 상태를 초기화 하는 경우 Context를 사용하라고 안내되어 있습니다.
- 요약하자면 다음과 같습니다.
  - 보안 결함(크로스 리퀘스트 오염) 방지: Zustand 단독 사용 시 발생하는 싱글톤 스토어 문제로 인해, 서버 메모리 상에서 유저 간 상태(로그인 여부 등)가 섞이거나 유출되는 치명적인 보안 사고를 방지해야 함.
  - 초기 화면 깜빡임(Hydration Mismatch) 해결: 클라이언트 단에서 스토어를 초기화할 때 발생하는 UI 전환(깜빡임) 딜레마를 서버 렌더링(SSR) 단계에서 원천 차단할 필요가 있음.
  - 안전한 스토어 격리 및 주입: 서버 컴포넌트 렌더링 시점에 매 요청 마다 유저 고유의 독립적인 스토어 인스턴스를 생성하고, 이를 Context API를 통해 클라이언트 트리에 안전하게 주입함.
  - 렌더링 성능 최적화 유지: Context에는 잦은 변경이 일어나는 '상태(State)'가 아닌 고정된 '스토어 객체(Instance)'만 담음. 이로써 하위 컴포넌트의 불필요한 리렌더링을 유발하는 Context API의 단점을 상쇄하고, 구독한 상태만 업데이트하는 Zustand 고유의 성능적 이점을 활용함.

## 리뷰 필요

X

close #185 
