### PR TITLE
refactor: 포폴 전략 생성 페이지 직무 선택 UI Select로 변경

### DIFF
--- a/src/features/strategy/components/sections/StrategyConditionPanel.tsx
+++ b/src/features/strategy/components/sections/StrategyConditionPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { Code, Info, Loader2, Server, Sparkles, Timer } from 'lucide-react';
+import { Info, Loader2, Sparkles, Timer } from 'lucide-react';
 import { JOB_LABEL_MAP } from '@/features/recruitment/constants/jobOptions';
 import { Switch } from '@/shared/components/ui/switch';
 import {
@@ -107,32 +107,23 @@ export default function StrategyConditionPanel({
         <div className="flex flex-col gap-2.5">
           <span className="text-[13px] font-semibold text-gray-700">직무 선택</span>
 
-          <div className="flex gap-2">
-            {(['FRONTEND', 'BACKEND'] as StrategyJobType[]).map((job) => {
-              const isActive = formData.selectedJob === job;
+          <Select
+            value={formData.selectedJob}
+            onValueChange={(value) => handleJobChange(value as StrategyJobType)}
+            disabled={isFormLocked}
+          >
+            <SelectTrigger className="h-10 w-full cursor-pointer border border-gray-200 text-[13px] font-medium text-gray-900 disabled:cursor-not-allowed disabled:opacity-50">
+              <SelectValue placeholder="직무를 선택하세요" />
+            </SelectTrigger>
 
-              return (
-                <Button
-                  key={job}
-                  type="button"
-                  onClick={() => handleJobChange(job)}
-                  disabled={isFormLocked}
-                  className={`inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 text-[13px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                    isActive
-                      ? 'border-[#2272eb] bg-[#2272eb] text-white'
-                      : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
-                  }`}
-                >
-                  {job === 'FRONTEND' ? (
-                    <Code className="h-3.5 w-3.5" />
-                  ) : (
-                    <Server className="h-3.5 w-3.5" />
-                  )}
+            <SelectContent position="popper">
+              {(['FRONTEND', 'BACKEND'] as StrategyJobType[]).map((job) => (
+                <SelectItem key={job} value={job} className="cursor-pointer text-[13px]">
                   {JOB_LABEL_MAP[job]}
-                </Button>
-              );
-            })}
-          </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
## 작업 내용

- 직무 선택 UI를 기존 Button(Radio 형태)에서 Select로 변경
- 기존 `selectedJob` 상태를 Select value에 연결하여 기존 동작 유지
- 선택 영역을 간결하게 정리해 입력 UI 밀도를 낮추도록 수정
- 산업 선택 UI와 동일한 Select 패턴으로 정리
- UI 변경에 따른 레이아웃 영향 범위 확인

## 리뷰 필요

1. 직무 선택 UI가 Select 형태로 변경되었을 때 데스크탑/태블릿/모바일 환경에서 사용성이 어색하지 않은지 확인 부탁드립니다.
2. 직무 선택 옵션은 현재 명세 기준으로 `FRONTEND`, `BACKEND`만 제공하도록 반영했는데, 추후 확장 가능성을 고려해야 하는지 확인 부탁드립니다.

close #192