### PR TITLE
refactor: 모바일 공고 상세 페이지 섹션 순서 조정

### DIFF
--- a/src/app/(main)/recruitment/[postId]/page.tsx
+++ b/src/app/(main)/recruitment/[postId]/page.tsx
@@ -27,9 +27,25 @@ export default async function RecruitmentDetailPage({ params }: RecruitmentDetai
 
   return (
     <div className="min-h-screen w-full bg-white font-sans">
-      <div className="mx-auto flex w-full max-w-7xl items-start gap-10 px-4 py-10 max-lg:flex-col max-lg:items-stretch max-lg:gap-6 max-lg:py-7 max-md:py-6 max-md:pb-[calc(env(safe-area-inset-bottom)+7rem)]">
-        <div className="flex min-w-0 flex-1 flex-col max-lg:w-full">
+      <div className="mx-auto w-full max-w-7xl px-4 py-10 max-lg:py-7 max-md:py-6 max-md:pb-[calc(env(safe-area-inset-bottom)+7rem)]">
+        <div className="hidden items-start gap-10 lg:flex">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <RecruitmentDetailOverview recruitment={recruitment} />
+
+            <div className="h-px bg-gray-100" />
+
+            <RecruitmentDetailContent
+              content={recruitment.originalContent ?? '공고 원문이 없습니다.'}
+            />
+          </div>
+
+          <RecruitmentAnalysisSection analysis={recruitment.analyzedContent} />
+        </div>
+
+        <div className="flex flex-col gap-6 lg:hidden">
           <RecruitmentDetailOverview recruitment={recruitment} />
+
+          <RecruitmentAnalysisSection analysis={recruitment.analyzedContent} />
 
           <div className="h-px bg-gray-100" />
 
@@ -37,9 +53,8 @@ export default async function RecruitmentDetailPage({ params }: RecruitmentDetai
             content={recruitment.originalContent ?? '공고 원문이 없습니다.'}
           />
         </div>
-
-        <RecruitmentAnalysisSection analysis={recruitment.analyzedContent} />
       </div>
+
       <FloatingActionButton
         href="/strategy/create"
         ariaLabel="포트폴리오 전략 생성 페이지로 이동"


### PR DESCRIPTION
## 작업 내용

- 모바일 공고 상세 페이지에서 공고 분석 섹션이 공고 원문보다 먼저 노출되도록 섹션 순서를 조정
- 데스크탑 레이아웃은 기존 구조를 유지하고, 모바일 레이아웃만 별도로 분기 처리
- 섹션 순서 변경에 맞춰 모바일 기준 레이아웃 흐름과 spacing을 함께 정리

## 리뷰 필요

1. 모바일 환경에서 공고 상세 페이지가 `개요 → 공고 분석 → 공고 원문` 순서로 자연스럽게 노출되는지 확인 부탁드립니다.
2. 데스크탑 환경에서는 기존 레이아웃과 섹션 배치가 의도대로 유지되는지 확인 부탁드립니다.

close #193 
