### PR TITLE
feat: 내 파일, 내 경험 페이지 자료정리 메뉴로 이동

### DIFF
--- a/src/app/(main)/resource/experience/page.tsx
+++ b/src/app/(main)/resource/experience/page.tsx
@@ -8,8 +8,8 @@ export default async function ExperiencePage() {
       <div className="flex flex-1 flex-col gap-6">
         {/* 페이지 타이틀 */}
         <Title
-          title={'내 경험'}
-          description={'나의 경험을 기록하고 AI로 의미 있는 단위로 추출해보세요'}
+          title={'경험 관리'}
+          description={'프로젝트, 경력, 수상내역 등의 경험을 관리합니다.'}
         />
         <ExperienceSection />
       </div>

--- a/src/app/(main)/resource/file/page.tsx
+++ b/src/app/(main)/resource/file/page.tsx
@@ -8,10 +8,7 @@ export default async function FilePage() {
       {/* 메인 영역 */}
       <div className="flex flex-1 flex-col gap-6">
         {/* 페이지 타이틀 */}
-        <Title
-          title={'내 파일'}
-          description={'포트폴리오, 이력서 등 첨부파일을 관리할 수 있습니다'}
-        />
+        <Title title={'파일 관리'} description={'포트폴리오, 이력서 등의 파일을 관리합니다'} />
         <FileSection />
       </div>
 

--- a/src/app/(main)/resource/layout.tsx
+++ b/src/app/(main)/resource/layout.tsx
@@ -1,0 +1,14 @@
+import ResourceTabs from '@/shared/components/layout/ResourceTabs';
+
+export default function ResourceLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="flex flex-col flex-1 w-full gap-4 px-4 pt-6 pb-10 md:min-h-180 md:pt-10 md:pb-20 md:gap-8">
+      <ResourceTabs />
+      {children}
+    </div>
+  );
+}

--- a/src/features/auth/components/ui/ProfileMenu.tsx
+++ b/src/features/auth/components/ui/ProfileMenu.tsx
@@ -121,8 +121,6 @@ const MENU_SECTIONS: MenuItem[][] = [
   [
     { icon: User, label: '프로필', href: '/my/profile' },
     { icon: Bookmark, label: '북마크', href: '/my/bookmark' },
-    { icon: Folder, label: '내 파일', href: '/my/file' },
-    { icon: Briefcase, label: '내 경험', href: '/my/experience' },
   ],
   [
     { icon: Lightbulb, label: '포폴 전략', href: '/my/strategy' },

--- a/src/features/experience/components/sections/ExperienceExtractionPollingListener.tsx
+++ b/src/features/experience/components/sections/ExperienceExtractionPollingListener.tsx
@@ -130,7 +130,7 @@ export default function ExperienceExtractionPollingListener() {
         toast.success('경험 추출이 완료되었어요.', {
           action: {
             label: '경험 확인하기',
-            onClick: () => router.push('/my/experience'),
+            onClick: () => router.push('/resource/experience'),
           },
         });
       }

--- a/src/features/experience/components/ui/ExperienceEmpty.tsx
+++ b/src/features/experience/components/ui/ExperienceEmpty.tsx
@@ -15,9 +15,7 @@ export default function ExperienceEmpty({ onAddCard }: ExperienceEmptyProps) {
       </div>
       <div className="flex flex-col items-center gap-1.5 text-center">
         <p className="text-[15px] font-semibold text-gray-900">아직 등록된 경험이 없어요</p>
-        <p className="text-[13px] text-gray-500">
-          나의 경험을 기록하고 AI로 의미있게 정리해 보세요
-        </p>
+        <p className="text-[13px] text-gray-500">프로젝트, 경력, 공모전 등의 경험을 등록해보세요</p>
       </div>
       <Button
         type="button"

--- a/src/features/experience/components/ui/ExperienceExtractBanner.tsx
+++ b/src/features/experience/components/ui/ExperienceExtractBanner.tsx
@@ -11,7 +11,7 @@ export default function ExperienceExtractBanner() {
         <div className="flex flex-col gap-0.5">
           <span className="text-[15px] font-bold text-blue-900">AI 경험 추출</span>
           <span className="text-[13px] text-blue-800">
-            업로드된 파일에서 AI가 의미 있는 경험 단위를 자동으로 추출해드립니다
+            업로드한 포트폴리오, 이력서에서 경험을 자동으로 추출할 수 있어요
           </span>
         </div>
       </div>

--- a/src/features/experience/components/ui/ExperienceExtractDialog.tsx
+++ b/src/features/experience/components/ui/ExperienceExtractDialog.tsx
@@ -92,7 +92,7 @@ export default function ExperienceExtractDialog({ files }: ExperienceExtractDial
                 </div>
               </div>
               <Link
-                href="/my/file"
+                href="/resource/file"
                 onClick={() => handleDialogOpenChange(false)}
                 className="text-[13px] font-semibold text-blue-600 hover:text-blue-800"
               >

--- a/src/features/experience/components/ui/ExperienceFileEmpty.tsx
+++ b/src/features/experience/components/ui/ExperienceFileEmpty.tsx
@@ -19,7 +19,7 @@ export default function ExperienceFileEmpty() {
         </p>
       </div>
       <Link
-        href="/my/file"
+        href="/resource/file"
         onClick={closeDialog}
         className="rounded-lg bg-gray-900 px-4 py-2.5 text-[14px] font-semibold text-white hover:bg-gray-700"
       >

--- a/src/features/interview/components/ui/PortfolioSelectDialog.tsx
+++ b/src/features/interview/components/ui/PortfolioSelectDialog.tsx
@@ -69,7 +69,7 @@ export default function PortfolioSelectDialog({ isOpen, onClose }: PortfolioSele
               </div>
 
               <Button asChild>
-                <Link href="/my/file" onClick={onClose}>
+                <Link href="/resource/file" onClick={onClose}>
                   파일 등록하러 가기
                 </Link>
               </Button>
@@ -83,7 +83,7 @@ export default function PortfolioSelectDialog({ isOpen, onClose }: PortfolioSele
                 </div>
 
                 <Button asChild variant="outline" size="sm" className="h-7 px-2.5 text-[11px]">
-                  <Link href="/my/file" onClick={onClose}>
+                  <Link href="/resource/file" onClick={onClose}>
                     <ExternalLink className="h-3 w-3 text-gray-500" />내 파일 관리
                   </Link>
                 </Button>

--- a/src/features/strategy/components/sections/StrategyExperienceSelectionSection.tsx
+++ b/src/features/strategy/components/sections/StrategyExperienceSelectionSection.tsx
@@ -82,7 +82,7 @@ export default function StrategyExperienceSelectionSection() {
             )}
 
             <Link
-              href="/my/experience"
+              href="/resource/experience"
               className="inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-3 text-[12px] font-medium text-gray-600 hover:bg-gray-50"
             >
               <ExternalLink className="h-3 w-3 shrink-0 text-gray-500" />
@@ -105,7 +105,7 @@ export default function StrategyExperienceSelectionSection() {
             </div>
 
             <Link
-              href="/my/experience"
+              href="/resource/experience"
               className="rounded-lg bg-gray-900 px-4 py-2 text-[13px] font-semibold text-white hover:bg-gray-700"
             >
               경험 등록하기

--- a/src/features/user/constants/navigation.ts
+++ b/src/features/user/constants/navigation.ts
@@ -20,8 +20,6 @@ export const ICON_MAP: Record<string, LucideIcon> = {
 export const MY_PAGE_NAV_ITEMS = [
   { href: '/my/profile', label: '프로필', iconKey: 'profile' },
   { href: '/my/bookmark', label: '북마크', iconKey: 'bookmark' },
-  { href: '/my/file', label: '내 파일', iconKey: 'file' },
-  { href: '/my/experience', label: '내 경험', iconKey: 'experience' },
   { href: '/my/strategy', label: '포폴 전략', iconKey: 'strategy' },
   { href: '/my/interview', label: '면접 질문', iconKey: 'interview' },
 ] as const;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,3 @@
-import { ReissueTokenResponse } from '@/features/auth/types';
-import { publicFetch } from '@/shared/api/httpClient';
 import { isProtectedRoute } from '@/shared/utils/isProtectedRoute';
 import { NextRequest, NextResponse } from 'next/server';
 

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -102,7 +102,7 @@ function HeaderContent({ currentPath }: HeaderContentProps) {
         </div>
 
         {showSearchBar && (
-          <div className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 lg:block">
+          <div className="absolute left-[58%] top-1/2 hidden -translate-x-1/2 -translate-y-1/2 lg:block">
             <Suspense fallback={null}>
               <SearchBar className="max-w-none w-72 xl:w-96" />
             </Suspense>
@@ -162,12 +162,17 @@ const NAV_ITEMS = [
     match: (path: string) => path === '/' || path.startsWith('/recruitment'),
   },
   {
+    label: '자료 정리',
+    href: '/resource/file',
+    match: (path: string) => path.startsWith('/resource'),
+  },
+  {
     label: '포폴 전략',
     href: '/strategy/create',
     match: (path: string) => path.startsWith('/strategy'),
   },
   {
-    label: '모의 면접',
+    label: '면접 질문',
     href: '/interview/create',
     match: (path: string) => path.startsWith('/interview'),
   },

--- a/src/shared/components/layout/ResourceTabs.tsx
+++ b/src/shared/components/layout/ResourceTabs.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function ResourceTabs() {
+  const pathname = usePathname();
+
+  const activeTab = pathname.split('/').pop() || 'file';
+
+  return (
+    <Tabs defaultValue={activeTab} className="w-full">
+      <TabsList variant="line" className="w-full gap-0">
+        <TabsTrigger value="file" asChild>
+          <Link href="/resource/file">파일 관리</Link>
+        </TabsTrigger>
+        <TabsTrigger value="experience" asChild>
+          <Link href="/resource/experience">경험 관리</Link>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/shared/utils/isProtectedRoute.ts
+++ b/src/shared/utils/isProtectedRoute.ts
@@ -1,5 +1,5 @@
 export const PROTECTED_ROUTES = {
-  PREFIXES: ['/my', '/strategy', '/interview'],
+  PREFIXES: ['/my', 'resource', '/strategy', '/interview'],
   PATTERNS: [/^\/strategy\/result\/\d+$/, /^\/interview\/result\/\d+$/],
 } as const;
 


### PR DESCRIPTION
## 작업 내용

- 헤더에 자료 정리 메뉴 추가 (기본 라우팅: `/resource/file`)
  - 헤더 메뉴 길이가 길어짐에 따라, 화면 사이즈에 따라서 검색 바에 메뉴가 가려지는 현상이 있어, 위치 조금 우측으로 이동함
- 내 파일, 내 경험 페이지를 자료정리 하위 메뉴로 이동
  - ResourceLayout 단에서 tab을 통해 하위 페이지 관리하도록 구현
  - ResourceTabs 구현 (파일 관리, 경험 관리에 포괄적으로 사용되어 `/shared/layout`에 우선 위치함)
- 기존 사용되던 `/my/file`, `my/experience` 라우팅 수정
- 보호라우트 규칙에 `/resource` 추가

## 리뷰 필요

1. 정상적으로 라우팅이 동작하는지 리뷰 필요
2. ResourceTabs의 파일 위치가 적절한지 확인 필요 
3. 탭의 디자인 피드백 필요 (우선 기본 shadcn 디자인으로 반영함)

close #202 
