### PR TITLE
style: 자료정리 페이지 탭 디자인 수정

### DIFF
--- a/src/app/(main)/resource/experience/page.tsx
+++ b/src/app/(main)/resource/experience/page.tsx
@@ -3,14 +3,10 @@ import ExperienceSection from '@/features/experience/components/sections/Experie
 
 export default async function ExperiencePage() {
   return (
-    <div className="flex flex-col w-full bg-white">
+    <div className="flex flex-col w-full">
       {/* 메인 영역 */}
       <div className="flex flex-1 flex-col gap-6">
         {/* 페이지 타이틀 */}
-        <Title
-          title={'경험 관리'}
-          description={'프로젝트, 경력, 수상내역 등의 경험을 관리합니다.'}
-        />
         <ExperienceSection />
       </div>
     </div>

--- a/src/app/(main)/resource/file/page.tsx
+++ b/src/app/(main)/resource/file/page.tsx
@@ -4,11 +4,10 @@ import FileSection from '@/features/file/components/sections/FileSection';
 
 export default async function FilePage() {
   return (
-    <div className="flex flex-col w-full bg-white">
+    <div className="flex flex-col w-full">
       {/* 메인 영역 */}
       <div className="flex flex-1 flex-col gap-6">
         {/* 페이지 타이틀 */}
-        <Title title={'파일 관리'} description={'포트폴리오, 이력서 등의 파일을 관리합니다'} />
         <FileSection />
       </div>
 

--- a/src/app/(main)/resource/layout.tsx
+++ b/src/app/(main)/resource/layout.tsx
@@ -1,4 +1,5 @@
 import ResourceTabs from '@/shared/components/layout/ResourceTabs';
+import Title from '@/shared/components/ui/Title';
 
 export default function ResourceLayout({
   children,
@@ -6,9 +7,15 @@ export default function ResourceLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="flex flex-col flex-1 w-full gap-4 px-4 pt-6 pb-10 md:min-h-180 md:pt-10 md:pb-20 md:gap-8">
-      <ResourceTabs />
-      {children}
+    <div className="flex flex-col flex-1 w-full gap-4 px-4 pt-6 pb-10 md:min-h-180 md:pt-10 md:pb-20 md:gap-4">
+      <Title
+        title={'자료 정리'}
+        description={'포트폴리오, 이력서 등의 파일과 나의 커리어 경험을 정리합니다'}
+      />
+      <div className="flex flex-col gap-4">
+        <ResourceTabs />
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/features/file/components/sections/FileSection.tsx
+++ b/src/features/file/components/sections/FileSection.tsx
@@ -14,7 +14,7 @@ export default function FileSection() {
   return (
     <>
       {/* 파일 개수 / 첨부파일 등록 버튼 */}
-      <div className="flex items-center justify-between relative">
+      <div className="flex items-center justify-between relative pt-4">
         <div className="flex items-center gap-1">
           <span className="text-sm font-medium text-gray-500">파일</span>
           <span className="text-sm font-bold text-gray-900">{currentFileCount ?? 0}</span>

--- a/src/features/recruitment/components/ui/MobileMainBottomNav.tsx
+++ b/src/features/recruitment/components/ui/MobileMainBottomNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { BriefcaseBusiness, Lightbulb, MessageSquareText } from 'lucide-react';
+import { BriefcaseBusiness, Lightbulb, MessageSquareText, NotebookTextIcon } from 'lucide-react';
 
 const NAV_ITEMS = [
   {
@@ -12,6 +12,12 @@ const NAV_ITEMS = [
     match: (path: string) => path === '/' || path.startsWith('/recruitment'),
   },
   {
+    href: '/resource/file',
+    label: '자료 정리',
+    icon: NotebookTextIcon,
+    match: (path: string) => path.startsWith('/resource'),
+  },
+  {
     href: '/strategy/create',
     label: '포폴 전략',
     icon: Lightbulb,
@@ -19,7 +25,7 @@ const NAV_ITEMS = [
   },
   {
     href: '/interview/create',
-    label: '모의 면접',
+    label: '면접 질문',
     icon: MessageSquareText,
     match: (path: string) => path.startsWith('/interview'),
   },
@@ -42,7 +48,9 @@ export default function MobileMainBottomNav() {
               className="flex min-w-0 flex-1 flex-col items-center justify-center gap-1"
             >
               <Icon className={`h-4 w-4 ${isActive ? 'text-gray-900' : 'text-gray-400'}`} />
-              <span className={`text-[11px] ${isActive ? 'font-semibold text-gray-900' : 'text-gray-500'}`}>
+              <span
+                className={`text-[11px] ${isActive ? 'font-semibold text-gray-900' : 'text-gray-500'}`}
+              >
                 {item.label}
               </span>
             </Link>

--- a/src/shared/components/layout/ResourceTabs.tsx
+++ b/src/shared/components/layout/ResourceTabs.tsx
@@ -1,22 +1,31 @@
 'use client';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
+import { Tabs, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { ICON_MAP } from '@/features/user/constants/navigation';
 
 export default function ResourceTabs() {
   const pathname = usePathname();
-
   const activeTab = pathname.split('/').pop() || 'file';
 
+  const FileIcon = ICON_MAP['file'];
+  const ExperienceIcon = ICON_MAP['experience'];
+
   return (
-    <Tabs defaultValue={activeTab} className="w-full">
-      <TabsList variant="line" className="w-full gap-0">
+    <Tabs value={activeTab} className="w-full">
+      <TabsList variant="default" className="w-full">
         <TabsTrigger value="file" asChild>
-          <Link href="/resource/file">파일 관리</Link>
+          <Link href="/resource/file" className="gap-2">
+            <FileIcon size={4} />
+            파일 관리
+          </Link>
         </TabsTrigger>
         <TabsTrigger value="experience" asChild>
-          <Link href="/resource/experience">경험 관리</Link>
+          <Link href="/resource/experience" className="gap-2">
+            <ExperienceIcon size={4} />
+            경험 관리
+          </Link>
         </TabsTrigger>
       </TabsList>
     </Tabs>

--- a/src/shared/components/ui/tabs.tsx
+++ b/src/shared/components/ui/tabs.tsx
@@ -1,14 +1,14 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Tabs as TabsPrimitive } from "radix-ui"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
 
-import { cn } from "@/shared/lib/cn"
+import { cn } from '@/shared/lib/cn';
 
 function Tabs({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
@@ -16,36 +16,32 @@ function Tabs({
       data-slot="tabs"
       data-orientation={orientation}
       orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
-        className
-      )}
+      className={cn('group/tabs flex gap-2 data-[orientation=horizontal]:flex-col', className)}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-1.5 text-muted-foreground group-data-[orientation=horizontal]/tabs:h-full group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
   {
     variants: {
       variant: {
-        default: "bg-muted",
-        line: "gap-1 bg-transparent",
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
-)
+  },
+);
 
 function TabsList({
   className,
-  variant = "default",
+  variant = 'default',
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List> &
-  VariantProps<typeof tabsListVariants>) {
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -53,39 +49,33 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
-        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
-        className
+        "relative inline-flex h-full flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
+        'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn('flex-1 outline-none', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };


### PR DESCRIPTION
## 작업 내용

- 자료 정리 페이지 탭 디자인 수정
  - 메인 타이틀을 상위로 올리고, 탭을 그 하위로 이동
  - 탭 디자인을 파일철 형태로 수정
- 모바일 바텀 네비게이션 자료 정리 메뉴 추가

## 리뷰 필요

1. 디자인이 적절한지 확인 필요

close #207 
