### PR TITLE
feat: 생성 기능 횟수 제한 UI 노출

### DIFF
--- a/src/features/experience/components/sections/ExperienceSection.tsx
+++ b/src/features/experience/components/sections/ExperienceSection.tsx
@@ -92,6 +92,7 @@ export default function ExperienceSection() {
 
   return (
     <>
+      {/* TODO: 경험 추출 availability API 추가 후 사용 횟수 UI 연결 */}
       {/* 경험 추출 배너 */}
       <ExperienceExtractBanner />
 

--- a/src/features/interview/components/sections/InterviewConditionalPanel.tsx
+++ b/src/features/interview/components/sections/InterviewConditionalPanel.tsx
@@ -10,6 +10,7 @@ import { useInterviewGenerationStore } from '@/features/interview/stores/useInte
 import { useStartInterviewGeneration } from '@/features/interview/hooks/useStartInterviewGeneration';
 import { useGetInterviewAvailability } from '@/features/interview/queries';
 import { TODAY_USAGE, DAILY_LIMIT } from '@/features/interview/constants/limit';
+import GenerationUsageCard from '@/shared/components/ui/GenerationUsageCard';
 
 export default function InterviewConditionalPanel() {
   const router = useRouter();
@@ -126,30 +127,12 @@ export default function InterviewConditionalPanel() {
           )}
         </div>
 
-        {/* <div className="flex items-center justify-between rounded-[10px] border border-blue-100 bg-blue-50 px-4 py-3">
-          <div className="flex flex-col gap-0.5">
-            <span className="text-[11px] font-medium text-blue-600">오늘 사용 횟수</span>
-            <div className="flex items-center gap-1">
-              <span className="text-[20px] font-bold text-blue-700">
-                {isAvailabilityLoading ? '-' : todayUsage}
-              </span>
-              <span className="text-[13px] font-medium text-blue-400">
-                / {isAvailabilityLoading ? '-' : `${dailyLimit}회`}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-1.5">
-            {Array.from({ length: dailyLimit }).map((_, i) => (
-              <div
-                key={i}
-                className={`h-2.5 w-2.5 rounded-full ${
-                  i < todayUsage ? 'bg-blue-500' : 'bg-blue-200'
-                }`}
-              />
-            ))}
-          </div>
-        </div> */}
+        <GenerationUsageCard
+          label="오늘 사용 횟수"
+          usedCount={todayUsage}
+          limitCount={dailyLimit}
+          isLoading={isAvailabilityLoading}
+        />
 
         <button
           type="button"

--- a/src/features/strategy/components/sections/StrategyConditionPanel.tsx
+++ b/src/features/strategy/components/sections/StrategyConditionPanel.tsx
@@ -21,6 +21,7 @@ import { useGetStrategyAvailability } from '@/features/strategy/queries';
 import { TODAY_USAGE, DAILY_LIMIT } from '@/features/strategy/constants/limit';
 import { cn } from '@/shared/lib/cn';
 import { useGetIndustryList } from '@/features/industry/queries';
+import GenerationUsageCard from '@/shared/components/ui/GenerationUsageCard';
 
 interface StrategyConditionPanelProps {
   variant?: 'sidebar' | 'sheet';
@@ -212,30 +213,13 @@ export default function StrategyConditionPanel({
         </div>
       </div>
 
-      {/* <div className="flex items-center justify-between rounded-[10px] border border-blue-100 bg-blue-50 px-4 py-3 max-md:px-3.5 max-md:py-2.5">
-        <div className="flex flex-col gap-0.5">
-          <span className="text-[11px] font-medium text-blue-600">오늘 사용 횟수</span>
-          <div className="flex items-center gap-1">
-            <span className="text-[20px] font-bold text-blue-700">
-              {isAvailabilityLoading ? '-' : todayUsage}
-            </span>
-            <span className="text-[13px] font-medium text-blue-400">
-              / {isAvailabilityLoading ? '-' : `${dailyLimit}회`}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-1.5">
-          {Array.from({ length: dailyLimit }).map((_, i) => (
-            <div
-              key={i}
-              className={`h-2.5 w-2.5 rounded-full ${
-                i < todayUsage ? 'bg-blue-500' : 'bg-blue-200'
-              }`}
-            />
-          ))}
-        </div>
-      </div> */}
+      <GenerationUsageCard
+        label="오늘 사용 횟수"
+        usedCount={todayUsage}
+        limitCount={dailyLimit}
+        isLoading={isAvailabilityLoading}
+        className="max-md:px-3.5 max-md:py-2.5"
+      />
 
       {variant === 'sidebar' && (
         <>

--- a/src/shared/components/ui/GenerationUsageCard.tsx
+++ b/src/shared/components/ui/GenerationUsageCard.tsx
@@ -1,0 +1,66 @@
+import { cn } from '@/shared/lib/cn';
+
+interface GenerationUsageCardProps {
+  label: string;
+  usedCount: number;
+  limitCount: number;
+  isLoading?: boolean;
+  className?: string;
+  variant?: 'default' | 'compact';
+}
+
+export default function GenerationUsageCard({
+  label,
+  usedCount,
+  limitCount,
+  isLoading = false,
+  className,
+  variant = 'default',
+}: GenerationUsageCardProps) {
+  const isCompact = variant === 'compact';
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between border border-blue-100 bg-blue-50',
+        isCompact ? 'min-w-40 rounded-lg px-3 py-2' : 'rounded-[10px] px-4 py-3',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-0.5">
+        <span
+          className={cn('font-medium text-blue-600', isCompact ? 'text-[10px]' : 'text-[11px]')}
+        >
+          {label}
+        </span>
+
+        <div className="flex items-center gap-1">
+          <span
+            className={cn('font-bold text-blue-700', isCompact ? 'text-[16px]' : 'text-[20px]')}
+          >
+            {isLoading ? '-' : usedCount}
+          </span>
+
+          <span
+            className={cn('font-medium text-blue-400', isCompact ? 'text-[11px]' : 'text-[13px]')}
+          >
+            / {isLoading ? '-' : `${limitCount}회`}
+          </span>
+        </div>
+      </div>
+
+      <div className={cn('flex items-center', isCompact ? 'gap-1' : 'gap-1.5')}>
+        {Array.from({ length: limitCount }).map((_, index) => (
+          <div
+            key={index}
+            className={cn(
+              'rounded-full',
+              isCompact ? 'h-2 w-2' : 'h-2.5 w-2.5',
+              index < usedCount ? 'bg-blue-500' : 'bg-blue-200',
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용

- 생성 사용 횟수 UI를 `GenerationUsageCard` 공통 컴포넌트로 분리
- 포트폴리오 전략 생성 패널에 사용 횟수 UI 적용
- 면접 질문 생성 패널에 사용 횟수 UI 적용
- 기존 availability API의 `usedCount`, `limitCount`, `canGenerate` 기준 표시 동작 유지
- 경험 추출 화면은 availability API 추가 후 연결할 위치 표시

## 리뷰 필요

- 현재는 availability API가 제공되는 포트폴리오 전략 생성/면접 질문 생성 화면에 먼저 적용했습니다.
- 경험 추출 화면도 동일한 사용 횟수 UI가 필요하지만, 현재 경험 추출용 availability API가 없어 후속 반영 예정입니다.
- 주간 7회 제한 정책 반영 시 기존 `usedCount`, `limitCount`가 주간 기준으로 내려오는지, 또는 별도 필드가 추가되는지 확인 부탁드립니다.
- 재시도 제한 관련 응답 스펙이 확정되면 `canRetry` 기준의 재시도 버튼 처리도 후속 반영 예정입니다.

close #197