### PR TITLE
feat: 히스토리 사이드바 접힘 UX 개선

### DIFF
--- a/src/app/(sidebar)/interview/layout.tsx
+++ b/src/app/(sidebar)/interview/layout.tsx
@@ -1,5 +1,5 @@
 import Footer from '@/shared/components/layout/Footer';
-import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/shared/components/ui/sidebar';
+import { SidebarInset, SidebarProvider } from '@/shared/components/ui/sidebar';
 import InterviewHistorySidebar from '@/features/interview/components/layout/InterviewHistorySidebar';
 import MobileInterviewHistoryTrigger from '@/features/interview/components/ui/MobileInterviewHistoryTrigger';
 
@@ -9,15 +9,14 @@ export default function InterviewLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <SidebarProvider defaultOpen>
+    <SidebarProvider defaultOpen className="min-h-0!">
       <InterviewHistorySidebar />
 
-      <SidebarInset className="min-h-[calc(100svh-5rem)] bg-white">
-        <div className="flex min-h-[calc(100svh-5rem)] flex-col">
-          <main className="min-h-0 flex-1 overflow-y-auto">
+      <SidebarInset className="min-h-0 bg-white transition-[padding-left] duration-200 md:peer-data-[state=collapsed]:pl-4">
+        <div className="flex min-h-0 flex-col">
+          <main>
             <div className="mx-auto flex w-full max-w-7xl flex-col px-4 pt-4 pb-6">
-              <div className="mb-2 flex items-center">
-                <SidebarTrigger className="hidden text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:inline-flex" />
+              <div className="mb-2 flex items-center md:hidden">
                 <MobileInterviewHistoryTrigger />
               </div>
 

--- a/src/app/(sidebar)/strategy/create/page.tsx
+++ b/src/app/(sidebar)/strategy/create/page.tsx
@@ -6,18 +6,18 @@ import MobileStrategyGenerateBar from '@/features/strategy/components/ui/MobileS
 export default async function StrategyCreatePage() {
   return (
     <div className="flex flex-col gap-8 bg-white font-sans">
-      <div className="flex flex-col gap-8 pt-0 pb-10 max-md:pb-[calc(env(safe-area-inset-bottom)+13rem)] md:max-lg:pb-[calc(env(safe-area-inset-bottom)+8rem)] max-md:gap-6">
+      <div className="flex flex-col gap-8 pt-0 pb-10 max-md:gap-6 max-md:pb-[calc(env(safe-area-inset-bottom)+13rem)] md:max-lg:pb-[calc(env(safe-area-inset-bottom)+8rem)]">
         <Title
           title="포폴 전략 생성"
           description="경험과 조건을 설정하여 나만의 포트폴리오 전략을 생성하세요"
         />
 
-        <div className="flex items-start gap-6 max-lg:flex-col max-lg:items-stretch max-lg:gap-5">
-          <div className="w-full">
+        <div className="flex min-w-0 items-start gap-6 max-xl:flex-col max-xl:items-stretch max-xl:gap-5">
+          <div className="min-w-0 flex-1 max-xl:w-full">
             <StrategyExperienceSelectionSection />
           </div>
 
-          <div className="max-lg:hidden">
+          <div className="min-w-0 shrink-0 max-lg:hidden max-xl:w-full">
             <StrategyConditionPanel />
           </div>
         </div>

--- a/src/app/(sidebar)/strategy/layout.tsx
+++ b/src/app/(sidebar)/strategy/layout.tsx
@@ -1,6 +1,6 @@
 import Footer from '@/shared/components/layout/Footer';
+import { SidebarInset, SidebarProvider } from '@/shared/components/ui/sidebar';
 import StrategyHistorySidebar from '@/features/strategy/components/layout/StrategyHistorySidebar';
-import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/shared/components/ui/sidebar';
 import MobileStrategyHistoryTrigger from '@/features/strategy/components/ui/MobileStrategyHistoryTrigger';
 
 export default function StrategyLayout({
@@ -9,15 +9,14 @@ export default function StrategyLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <SidebarProvider defaultOpen>
+    <SidebarProvider defaultOpen className="min-h-0!">
       <StrategyHistorySidebar />
 
-      <SidebarInset className="min-h-[calc(100svh-5rem)] bg-white">
-        <div className="flex min-h-[calc(100svh-5rem)] flex-col">
-          <main className="min-h-0 flex-1 overflow-y-auto">
+      <SidebarInset className="min-h-0 bg-white transition-[padding-left] duration-200 md:peer-data-[state=collapsed]:pl-4">
+        <div className="flex min-h-0 flex-col">
+          <main>
             <div className="mx-auto flex w-full max-w-7xl flex-col px-4 pt-4 pb-6 max-md:pb-[calc(env(safe-area-inset-bottom)+7.5rem)]">
-              <div className="mb-2 flex items-center">
-                <SidebarTrigger className="hidden text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:inline-flex" />
+              <div className="mb-2 flex items-center md:hidden">
                 <MobileStrategyHistoryTrigger />
               </div>
 

--- a/src/shared/components/layout/HistorySidebar.tsx
+++ b/src/shared/components/layout/HistorySidebar.tsx
@@ -79,9 +79,9 @@ export default function HistorySidebar({
                 )}
               </div>
 
-              <div className="flex min-w-0 flex-col group-data-[collapsible=icon]:hidden">
+              <div className="flex min-w-0 overflow-hidden whitespace-nowrap flex-col group-data-[collapsible=icon]:hidden">
                 <span
-                  className={`truncate text-[12px] font-semibold leading-4 ${
+                  className={`truncate whitespace-nowrap text-[12px] font-semibold leading-4 ${
                     isActive ? 'text-[#1b64da]' : 'text-gray-700'
                   }`}
                 >
@@ -109,7 +109,7 @@ export default function HistorySidebar({
     >
       <SidebarHeader className="gap-4 px-4 pt-5 pb-4 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-2">
         <div className="flex items-center justify-between group-data-[collapsible=icon]:justify-center">
-          <span className="text-[13px] font-semibold text-gray-700 group-data-[collapsible=icon]:hidden">
+          <span className="overflow-hidden whitespace-nowrap text-[13px] font-semibold text-gray-700 group-data-[collapsible=icon]:hidden">
             {title}
           </span>
 
@@ -123,7 +123,9 @@ export default function HistorySidebar({
           className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3.5 py-2.5 text-[13px] font-semibold text-white transition-colors hover:bg-blue-700 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0"
         >
           <Plus className="h-3.5 w-3.5 shrink-0" />
-          <span className="group-data-[collapsible=icon]:hidden">{createLabel}</span>
+          <span className="overflow-hidden whitespace-nowrap group-data-[collapsible=icon]:hidden">
+            {createLabel}
+          </span>
         </Link>
       </SidebarHeader>
 
@@ -163,7 +165,9 @@ export default function HistorySidebar({
           className="flex items-center gap-1.5 text-[12px] font-medium text-gray-500 transition-colors hover:text-gray-700 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0"
         >
           <Settings2 className="h-3.5 w-3.5 shrink-0 text-gray-400" />
-          <span className="group-data-[collapsible=icon]:hidden">{manageLabel}</span>
+          <span className="overflow-hidden whitespace-nowrap group-data-[collapsible=icon]:hidden">
+            {manageLabel}
+          </span>
         </Link>
       </SidebarFooter>
     </Sidebar>

--- a/src/shared/components/layout/HistorySidebar.tsx
+++ b/src/shared/components/layout/HistorySidebar.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarTrigger,
   useSidebar,
 } from '@/shared/components/ui/sidebar';
 import { HistorySidebarItem } from '@/shared/types';
@@ -57,7 +58,8 @@ export default function HistorySidebar({
             <Link
               href={item.href}
               onClick={closeMobileSidebar}
-              className={`flex gap-2.5 rounded-lg border px-3 py-2.5 ${
+              title={item.title}
+              className={`flex gap-2.5 rounded-lg border px-3 py-2.5 transition-colors group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0 ${
                 isActive ? 'border-[#90c2ff] bg-[#e8f3ff]' : 'border-transparent hover:bg-gray-100'
               }`}
             >
@@ -77,7 +79,7 @@ export default function HistorySidebar({
                 )}
               </div>
 
-              <div className="flex min-w-0 flex-col">
+              <div className="flex min-w-0 flex-col group-data-[collapsible=icon]:hidden">
                 <span
                   className={`truncate text-[12px] font-semibold leading-4 ${
                     isActive ? 'text-[#1b64da]' : 'text-gray-700'
@@ -102,32 +104,38 @@ export default function HistorySidebar({
 
   return (
     <Sidebar
-      collapsible="offcanvas"
-      className="top-20 h-[calc(100svh-5rem)] border-r border-gray-100 bg-gray-50 [--sidebar-width:16rem]"
+      collapsible="icon"
+      className="top-20 h-[calc(100svh-5rem)] border-r border-gray-100 bg-gray-50 [--sidebar-width:16rem] [--sidebar-width-icon:4rem]"
     >
-      <SidebarHeader className="gap-4 px-4 pb-4 pt-5">
-        <div className="flex items-center justify-between">
-          <span className="text-[13px] font-semibold text-gray-700">{title}</span>
+      <SidebarHeader className="gap-4 px-4 pt-5 pb-4 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-2">
+        <div className="flex items-center justify-between group-data-[collapsible=icon]:justify-center">
+          <span className="text-[13px] font-semibold text-gray-700 group-data-[collapsible=icon]:hidden">
+            {title}
+          </span>
+
+          <SidebarTrigger className="h-8 w-8 text-gray-500 hover:bg-gray-100 hover:text-gray-700" />
         </div>
 
         <Link
           href={createHref}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3.5 py-2.5 text-[13px] font-semibold text-white hover:bg-blue-700"
+          onClick={closeMobileSidebar}
+          title={createLabel}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3.5 py-2.5 text-[13px] font-semibold text-white transition-colors hover:bg-blue-700 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0"
         >
-          <Plus className="h-3.5 w-3.5" />
-          {createLabel}
+          <Plus className="h-3.5 w-3.5 shrink-0" />
+          <span className="group-data-[collapsible=icon]:hidden">{createLabel}</span>
         </Link>
       </SidebarHeader>
 
-      <SidebarContent className="px-2">
+      <SidebarContent className="px-2 group-data-[collapsible=icon]:items-center">
         {processingItems.length > 0 && processingLabel && (
           <SidebarGroup className="gap-2 p-0">
-            <SidebarGroupLabel className="px-3 py-1 text-[11px] font-semibold text-gray-400">
+            <SidebarGroupLabel className="px-3 py-1 text-[11px] font-semibold text-gray-400 group-data-[collapsible=icon]:hidden">
               {processingLabel}
             </SidebarGroupLabel>
 
             <SidebarGroupContent>
-              <SidebarMenu className="gap-0.5">
+              <SidebarMenu className="gap-0.5 group-data-[collapsible=icon]:items-center">
                 {renderMenuItems(processingItems, true)}
               </SidebarMenu>
             </SidebarGroupContent>
@@ -135,23 +143,27 @@ export default function HistorySidebar({
         )}
 
         <SidebarGroup className="gap-2 p-0">
-          <SidebarGroupLabel className="px-3 py-1 text-[11px] font-semibold text-gray-400">
+          <SidebarGroupLabel className="px-3 py-1 text-[11px] font-semibold text-gray-400 group-data-[collapsible=icon]:hidden">
             히스토리
           </SidebarGroupLabel>
 
           <SidebarGroupContent>
-            <SidebarMenu className="gap-0.5">{renderMenuItems(items)}</SidebarMenu>
+            <SidebarMenu className="gap-0.5 group-data-[collapsible=icon]:items-center">
+              {renderMenuItems(items)}
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="border-t border-gray-100 px-4 py-3.5">
+      <SidebarFooter className="border-t border-gray-100 px-4 py-3.5 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-2">
         <Link
           href={manageHref}
-          className="flex items-center gap-1.5 text-[12px] font-medium text-gray-500 hover:text-gray-700"
+          onClick={closeMobileSidebar}
+          title={manageLabel}
+          className="flex items-center gap-1.5 text-[12px] font-medium text-gray-500 transition-colors hover:text-gray-700 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0"
         >
-          <Settings2 className="h-3.5 w-3.5 text-gray-400" />
-          {manageLabel}
+          <Settings2 className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+          <span className="group-data-[collapsible=icon]:hidden">{manageLabel}</span>
         </Link>
       </SidebarFooter>
     </Sidebar>


### PR DESCRIPTION
## 작업 내용

- **히스토리 사이드바 접힘 UI 정리**
  - 접힘 상태에서도 새 생성/관리/히스토리 진입점이 아이콘 형태로 유지되도록 정리
  - 생성 중인 히스토리 항목도 로딩 아이콘으로 확인할 수 있도록 처리
  - 접힘 상태에서 사이드바 제목, 생성 버튼 텍스트, 히스토리 제목/날짜 텍스트 숨김 처리
- **사이드바 토글 및 페이지 레이아웃 조정**
  - 데스크톱 사이드바 토글 버튼을 메인 콘텐츠 영역에서 사이드바 내부로 이동
  - 사이드바 접힘 상태에서 본문이 아이콘 레일에 붙어 보이지 않도록 `SidebarInset`에 조건부 좌측 여백 적용
  - 모바일 네비 기준으로 적용되어 있던 `5rem` 높이 계산 제거
- **포폴 전략 생성 화면 가로 스크롤 방지**
  - 가용 폭이 줄어든 경우에도 가로 스크롤이 생기지 않도록 레이아웃 조정

## 리뷰 필요

- 사이드바 접힘 상태를 완전 숨김이 아니라 아이콘 레일을 유지하는 방식으로 정리했습니다. 자연스러운지 확인 부탁드립니다.
- 접힘 상태에서도 새 생성/관리 진입점과 일반/생성 중 히스토리 항목이 아이콘만으로 충분히 인지되는지 확인 부탁드립니다.

close #194