### PR TITLE
fix: 공고 목록 페이지 dead zone 가로 스크롤 제거

### DIFF
--- a/src/features/recruitment/components/ui/CategoryTabs.tsx
+++ b/src/features/recruitment/components/ui/CategoryTabs.tsx
@@ -25,7 +25,7 @@ export default function CategoryTabs({ activeTab, search }: CategoryTabsProps) {
   return (
     <div
       role="tablist"
-      className="flex min-w-0 w-full max-w-full border-b border-gray-200 max-md:overflow-x-auto max-md:overscroll-x-contain max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
+      className="flex w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain border-b border-gray-200 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       {TABS.map((tab) => {
         const isActive = activeTab === tab.value;


### PR DESCRIPTION
## 작업 내용

- 카테고리 탭 overflow 처리 수정
- 공고 목록 페이지 가로 스크롤 방지

## 리뷰 필요

- 공고 목록 페이지에서 우측 dead zone이 사라졌는지 확인 부탁드립니다.
- 모바일/데스크톱에서 카테고리 탭 스크롤 동작 확인 부탁드립니다.

close #157