### PR TITLE
refactor: AI 생성 대기 상태 안내 UI 보완

### DIFF
--- a/src/app/(sidebar)/interview/result/[interviewId]/page.tsx
+++ b/src/app/(sidebar)/interview/result/[interviewId]/page.tsx
@@ -4,7 +4,7 @@ import InterviewQuestionListSkeleton from '@/features/interview/components/secti
 import InterviewTipsPanel from '@/features/interview/components/sections/InterviewTipsPanel';
 import InterviewMetaBar from '@/features/interview/components/ui/InterviewMetaBar';
 import InterviewMetaBarSkeleton from '@/features/interview/components/ui/InterviewMetaBarSkeleton';
-
+import GenerationPendingNotice from '@/shared/components/ui/GenerationPendingNotice';
 import Title from '@/shared/components/ui/Title';
 
 interface InterviewResultPageProps {
@@ -25,6 +25,13 @@ export default async function InterviewResultPage({ params }: InterviewResultPag
           description="AI가 생성한 맞춤형 면접 질문입니다. 생성 시 자동으로 저장됩니다."
         />
 
+        {!interview && (
+          <GenerationPendingNotice
+            title="면접 질문을 생성하고 있어요"
+            description="AI가 공고와 입력 정보를 바탕으로 맞춤형 질문을 구성하는 중입니다. 결과가 준비되면 자동으로 저장되고 화면에 표시됩니다."
+          />
+        )}
+
         {interview ? <InterviewMetaBar interview={interview} /> : <InterviewMetaBarSkeleton />}
 
         <div className="flex flex-1 gap-6 max-lg:flex-col max-lg:gap-5">
@@ -33,6 +40,7 @@ export default async function InterviewResultPage({ params }: InterviewResultPag
           ) : (
             <InterviewQuestionListSkeleton />
           )}
+
           <InterviewTipsPanel />
         </div>
       </div>

--- a/src/app/(sidebar)/interview/result/[interviewId]/page.tsx
+++ b/src/app/(sidebar)/interview/result/[interviewId]/page.tsx
@@ -1,10 +1,8 @@
 import { getInterview } from '@/features/interview/actions';
 import InterviewQuestionListSection from '@/features/interview/components/sections/InterviewQuestionListSection';
-import InterviewQuestionListSkeleton from '@/features/interview/components/sections/InterviewQuestionListSkeleton';
 import InterviewTipsPanel from '@/features/interview/components/sections/InterviewTipsPanel';
 import InterviewMetaBar from '@/features/interview/components/ui/InterviewMetaBar';
-import InterviewMetaBarSkeleton from '@/features/interview/components/ui/InterviewMetaBarSkeleton';
-import GenerationPendingNotice from '@/shared/components/ui/GenerationPendingNotice';
+import GenerationPendingState from '@/shared/components/ui/GenerationPendingState';
 import Title from '@/shared/components/ui/Title';
 
 interface InterviewResultPageProps {
@@ -20,29 +18,31 @@ export default async function InterviewResultPage({ params }: InterviewResultPag
   return (
     <div className="flex flex-col gap-8 bg-white font-sans">
       <div className="flex flex-col gap-8 pt-0 pb-10 max-md:gap-6">
-        <Title
-          title="면접 질문 결과"
-          description="AI가 생성한 맞춤형 면접 질문입니다. 생성 시 자동으로 저장됩니다."
-        />
+        {interview ? (
+          <>
+            <Title
+              title="면접 질문 결과"
+              description="AI가 생성한 맞춤형 면접 질문입니다. 생성 시 자동으로 저장됩니다."
+            />
 
-        {!interview && (
-          <GenerationPendingNotice
+            <InterviewMetaBar interview={interview} />
+
+            <div className="flex flex-1 gap-6 max-lg:flex-col max-lg:gap-5">
+              <InterviewQuestionListSection interview={interview} />
+              <InterviewTipsPanel />
+            </div>
+          </>
+        ) : (
+          <GenerationPendingState
             title="면접 질문을 생성하고 있어요"
-            description="AI가 공고와 입력 정보를 바탕으로 맞춤형 질문을 구성하는 중입니다. 결과가 준비되면 자동으로 저장되고 화면에 표시됩니다."
+            description="AI가 공고와 입력 정보를 바탕으로 맞춤 면접 질문을 만들고 있어요."
+            tips={[
+              '질문을 확인한 뒤에는 STAR 구조로 답변 흐름을 정리해보면 좋아요.',
+              '경험, 직무 역량, 협업 상황으로 나누어 답변을 준비해보세요.',
+              '질문 의도까지 함께 생각해보면 답변 준비에 더 도움이 돼요.',
+            ]}
           />
         )}
-
-        {interview ? <InterviewMetaBar interview={interview} /> : <InterviewMetaBarSkeleton />}
-
-        <div className="flex flex-1 gap-6 max-lg:flex-col max-lg:gap-5">
-          {interview ? (
-            <InterviewQuestionListSection interview={interview} />
-          ) : (
-            <InterviewQuestionListSkeleton />
-          )}
-
-          <InterviewTipsPanel />
-        </div>
       </div>
     </div>
   );

--- a/src/app/(sidebar)/strategy/result/[strategyId]/page.tsx
+++ b/src/app/(sidebar)/strategy/result/[strategyId]/page.tsx
@@ -1,9 +1,10 @@
+import { getStrategyDetail } from '@/features/strategy/actions';
 import StrategyAnalysisPanel from '@/features/strategy/components/sections/StrategyAnalysisPanel';
+import StrategyPanelsSkeleton from '@/features/strategy/components/sections/StrategyPanelsSkeleton';
 import StrategyStructuredDataPanel from '@/features/strategy/components/sections/StrategyStructuredDataPanel';
 import StrategyMetaBar from '@/features/strategy/components/ui/StrategyMetaBar';
 import StrategyMetaBarSkeleton from '@/features/strategy/components/ui/StrategyMetaBarSkeleton';
-import StrategyPanelsSkeleton from '@/features/strategy/components/sections/StrategyPanelsSkeleton';
-import { getStrategyDetail } from '@/features/strategy/actions';
+import GenerationPendingNotice from '@/shared/components/ui/GenerationPendingNotice';
 import Title from '@/shared/components/ui/Title';
 
 interface StrategyResultPageProps {
@@ -23,6 +24,13 @@ export default async function StrategyResultPage({ params }: StrategyResultPageP
           title="포폴 전략 결과"
           description="AI가 생성한 산업 맞춤형 포트폴리오 전략입니다. 생성 시 자동으로 저장됩니다."
         />
+
+        {!strategy && (
+          <GenerationPendingNotice
+            title="포트폴리오 전략을 생성하고 있어요"
+            description="AI가 입력 정보를 바탕으로 전략을 정리하는 중입니다. 결과가 준비되면 자동으로 저장되고 화면에 표시됩니다."
+          />
+        )}
 
         {strategy ? <StrategyMetaBar strategy={strategy} /> : <StrategyMetaBarSkeleton />}
 

--- a/src/app/(sidebar)/strategy/result/[strategyId]/page.tsx
+++ b/src/app/(sidebar)/strategy/result/[strategyId]/page.tsx
@@ -1,10 +1,8 @@
 import { getStrategyDetail } from '@/features/strategy/actions';
 import StrategyAnalysisPanel from '@/features/strategy/components/sections/StrategyAnalysisPanel';
-import StrategyPanelsSkeleton from '@/features/strategy/components/sections/StrategyPanelsSkeleton';
 import StrategyStructuredDataPanel from '@/features/strategy/components/sections/StrategyStructuredDataPanel';
 import StrategyMetaBar from '@/features/strategy/components/ui/StrategyMetaBar';
-import StrategyMetaBarSkeleton from '@/features/strategy/components/ui/StrategyMetaBarSkeleton';
-import GenerationPendingNotice from '@/shared/components/ui/GenerationPendingNotice';
+import GenerationPendingState from '@/shared/components/ui/GenerationPendingState';
 import Title from '@/shared/components/ui/Title';
 
 interface StrategyResultPageProps {
@@ -20,31 +18,34 @@ export default async function StrategyResultPage({ params }: StrategyResultPageP
   return (
     <div className="flex flex-col gap-8 bg-white font-sans">
       <div className="flex flex-col gap-8 pt-0 pb-10 max-md:gap-6 max-md:pb-8">
-        <Title
-          title="포폴 전략 결과"
-          description="AI가 생성한 산업 맞춤형 포트폴리오 전략입니다. 생성 시 자동으로 저장됩니다."
-        />
-
-        {!strategy && (
-          <GenerationPendingNotice
-            title="포트폴리오 전략을 생성하고 있어요"
-            description="AI가 입력 정보를 바탕으로 전략을 정리하는 중입니다. 결과가 준비되면 자동으로 저장되고 화면에 표시됩니다."
-          />
-        )}
-
-        {strategy ? <StrategyMetaBar strategy={strategy} /> : <StrategyMetaBarSkeleton />}
-
         {strategy ? (
-          <div className="flex items-start gap-6 max-lg:flex-col max-lg:items-stretch max-lg:gap-5">
-            <StrategyAnalysisPanel
-              mainPositioningMessage={strategy.mainPositioningMessage}
-              experienceStrategyPoints={strategy.experienceStrategyPoints}
-              experienceOrdering={strategy.experienceOrdering}
+          <>
+            <Title
+              title="포폴 전략 결과"
+              description="AI가 생성한 산업 맞춤형 포트폴리오 전략입니다. 생성 시 자동으로 저장됩니다."
             />
-            <StrategyStructuredDataPanel detail={strategy} />
-          </div>
+
+            <StrategyMetaBar strategy={strategy} />
+
+            <div className="flex items-start gap-6 max-lg:flex-col max-lg:items-stretch max-lg:gap-5">
+              <StrategyAnalysisPanel
+                mainPositioningMessage={strategy.mainPositioningMessage}
+                experienceStrategyPoints={strategy.experienceStrategyPoints}
+                experienceOrdering={strategy.experienceOrdering}
+              />
+              <StrategyStructuredDataPanel detail={strategy} />
+            </div>
+          </>
         ) : (
-          <StrategyPanelsSkeleton />
+          <GenerationPendingState
+            title="포트폴리오 전략을 생성하고 있어요"
+            description="AI가 입력 정보를 바탕으로 맞춤 포트폴리오 전략을 만들고 있어요."
+            tips={[
+              '전략의 핵심 메시지와 경험 정리 방향까지 함께 확인해보면 포트폴리오 구성에 더 도움이 돼요.',
+              '완성된 전략은 포트폴리오에 넣을 경험의 순서를 정할 때 참고해보세요.',
+              '강조 키워드와 보완 가이드를 함께 보면 지원 직무에 맞는 방향을 잡기 쉬워요.',
+            ]}
+          />
         )}
       </div>
     </div>

--- a/src/shared/components/ui/GenerationPendingNotice.tsx
+++ b/src/shared/components/ui/GenerationPendingNotice.tsx
@@ -1,0 +1,27 @@
+interface GenerationPendingNoticeProps {
+  title: string;
+  description: string;
+}
+
+export default function GenerationPendingNotice({
+  title,
+  description,
+}: GenerationPendingNoticeProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-3 rounded-2xl border border-blue-100 bg-blue-50 px-5 py-4"
+    >
+      <div className="relative mt-1.5 flex h-2.5 w-2.5 shrink-0">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
+        <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-blue-500" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-semibold text-blue-900">{title}</p>
+        <p className="text-sm leading-6 text-blue-700">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/ui/GenerationPendingState.tsx
+++ b/src/shared/components/ui/GenerationPendingState.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { useId } from 'react';
+import usePendingProgress from '@/shared/hooks/usePendingProgress';
+import useRotatingText from '@/shared/hooks/useRotatingText';
+
+const TIP_INTERVAL = 4500;
+const TIP_FADE_DURATION = 250;
+
+interface GenerationPendingStateProps {
+  title: string;
+  description: string;
+  tips: string[];
+}
+
+export default function GenerationPendingState({
+  title,
+  description,
+  tips,
+}: GenerationPendingStateProps) {
+  const titleId = useId();
+  const progress = usePendingProgress();
+  const { currentText: currentTip, isVisible: isTipVisible } = useRotatingText(tips, {
+    interval: TIP_INTERVAL,
+    fadeDuration: TIP_FADE_DURATION,
+  });
+
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-labelledby={titleId}
+      className="flex min-h-120 w-full flex-col items-center justify-center py-12 text-center max-md:min-h-105 max-md:py-8"
+    >
+      <GeneratingIcon />
+
+      <h2
+        id={titleId}
+        className="mt-6 text-[26px] font-bold leading-tight tracking-[-0.02em] text-gray-900 max-md:text-[22px]"
+      >
+        {title}
+      </h2>
+
+      <PendingProgressBar progress={progress} />
+      <PendingDescription description={description} />
+      <TipBox tip={currentTip} isVisible={isTipVisible} />
+    </section>
+  );
+}
+
+function GeneratingIcon() {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative flex h-16 w-16 items-center justify-center rounded-2xl bg-white shadow-sm ring-1 ring-gray-100 max-md:h-14 max-md:w-14"
+    >
+      <div className="grid grid-cols-2 gap-1.5 max-md:gap-1">
+        <span className="h-3.5 w-3.5 animate-bounce rounded-md bg-blue-500 [animation-delay:0ms] max-md:h-3 max-md:w-3" />
+        <span className="h-3.5 w-3.5 animate-bounce rounded-md bg-blue-300 [animation-delay:150ms] max-md:h-3 max-md:w-3" />
+        <span className="h-3.5 w-3.5 animate-bounce rounded-md bg-blue-300 [animation-delay:300ms] max-md:h-3 max-md:w-3" />
+        <span className="h-3.5 w-3.5 animate-bounce rounded-md bg-blue-500 [animation-delay:450ms] max-md:h-3 max-md:w-3" />
+      </div>
+
+      <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-50 ring-2 ring-white max-md:h-4 max-md:w-4">
+        <Sparkles className="h-3 w-3 animate-pulse text-blue-500 max-md:h-2.5 max-md:w-2.5" />
+      </span>
+    </div>
+  );
+}
+
+interface PendingProgressBarProps {
+  progress: number;
+}
+
+function PendingProgressBar({ progress }: PendingProgressBarProps) {
+  return (
+    <div className="mt-7 h-1.5 w-full max-w-100 overflow-hidden rounded-full bg-gray-100 max-md:mt-6">
+      <div
+        className="h-full rounded-full bg-blue-500 transition-all duration-700 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}
+
+interface PendingDescriptionProps {
+  description: string;
+}
+
+function PendingDescription({ description }: PendingDescriptionProps) {
+  return (
+    <div className="mt-7 flex flex-col gap-1.5 text-center max-md:mt-6">
+      <p className="text-[15px] font-medium leading-7 text-gray-700 max-md:text-sm max-md:leading-6">
+        {description}
+      </p>
+      <p className="text-[15px] font-medium leading-7 text-gray-700 max-md:text-sm max-md:leading-6">
+        완료되면 자동으로 저장되고 결과 페이지에 표시됩니다.
+      </p>
+      <p className="text-sm font-medium leading-6 text-gray-500 max-md:text-[13px]">
+        다른 화면으로 이동해도 히스토리에서 다시 확인할 수 있어요.
+      </p>
+    </div>
+  );
+}
+
+interface TipBoxProps {
+  tip: string;
+  isVisible: boolean;
+}
+
+function TipBox({ tip, isVisible }: TipBoxProps) {
+  return (
+    <div className="mt-8 flex h-28 w-full max-w-130 flex-col rounded-2xl bg-gray-50 px-5 py-4 text-left max-md:mt-7 max-md:px-4">
+      <p className="shrink-0 text-sm font-bold text-blue-600">tip</p>
+      <p
+        className={`mt-2 overflow-hidden text-sm leading-7 text-gray-700 transition-all duration-300 ease-out max-md:leading-6 ${
+          isVisible ? 'translate-y-0 opacity-100' : 'translate-y-1 opacity-0'
+        }`}
+      >
+        {tip}
+      </p>
+    </div>
+  );
+}

--- a/src/shared/hooks/usePendingProgress.ts
+++ b/src/shared/hooks/usePendingProgress.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface UsePendingProgressOptions {
+  initialProgress?: number;
+  maxProgress?: number;
+  interval?: number;
+}
+
+const DEFAULT_INITIAL_PROGRESS = 18;
+const DEFAULT_MAX_PROGRESS = 94;
+const DEFAULT_INTERVAL = 900;
+
+export default function usePendingProgress({
+  initialProgress = DEFAULT_INITIAL_PROGRESS,
+  maxProgress = DEFAULT_MAX_PROGRESS,
+  interval = DEFAULT_INTERVAL,
+}: UsePendingProgressOptions = {}) {
+  const [progress, setProgress] = useState(initialProgress);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= maxProgress) return prev;
+
+        const increment = prev < 50 ? 8 : prev < 75 ? 5 : 2;
+        return Math.min(prev + increment, maxProgress);
+      });
+    }, interval);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [maxProgress, interval]);
+
+  return progress;
+}

--- a/src/shared/hooks/useRotatingText.ts
+++ b/src/shared/hooks/useRotatingText.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface UseRotatingTextOptions {
+  interval?: number;
+  fadeDuration?: number;
+}
+
+const DEFAULT_INTERVAL = 4500;
+const DEFAULT_FADE_DURATION = 250;
+
+export default function useRotatingText(texts: string[], options: UseRotatingTextOptions = {}) {
+  const { interval = DEFAULT_INTERVAL, fadeDuration = DEFAULT_FADE_DURATION } = options;
+
+  const [textIndex, setTextIndex] = useState(0);
+  const [isVisible, setIsVisible] = useState(true);
+  const fadeTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (texts.length <= 1) return;
+
+    const intervalTimer = window.setInterval(() => {
+      setIsVisible(false);
+
+      if (fadeTimerRef.current !== null) {
+        window.clearTimeout(fadeTimerRef.current);
+      }
+
+      fadeTimerRef.current = window.setTimeout(() => {
+        setTextIndex((prev) => (prev + 1) % texts.length);
+        setIsVisible(true);
+        fadeTimerRef.current = null;
+      }, fadeDuration);
+    }, interval);
+
+    return () => {
+      window.clearInterval(intervalTimer);
+
+      if (fadeTimerRef.current !== null) {
+        window.clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = null;
+      }
+    };
+  }, [texts.length, interval, fadeDuration]);
+
+  const safeTextIndex = texts.length > 0 ? textIndex % texts.length : 0;
+
+  return {
+    currentText: texts[safeTextIndex] ?? '',
+    isVisible,
+  };
+}


### PR DESCRIPTION
## 작업 내용

- AI 생성 결과 대기 상태를 안내하는 공통 UI 추가
  - 생성 중 상태를 시각적으로 인지할 수 있도록 생성 아이콘, 진행 바, 안내 문구, tip 영역 구성
  - 일정 시간마다 tip 문구가 전환되도록 `useRotatingText` 훅 추가
  - 생성 대기 상태를 진행 바 형태로 표현하기 위해 `usePendingProgress` 훅 추가
  - 생성 중 안내 영역에 `role="status"`, `aria-live="polite"` 적용
- 포트폴리오 전략 결과 화면에 생성 대기 상태 UI 적용
- 면접 질문 결과 화면에 생성 대기 상태 UI 적용
- 결과 데이터가 없는 경우 기존 스켈레톤 대신 생성 대기 안내 화면을 표시하도록 변경

## 리뷰 필요

- 사이드바의 생성 중 상태 표시는 유지하고, 결과 화면에서는 생성 진행 상황을 더 명확히 인지할 수 있도록 전용 대기 UI를 적용했습니다.
- 진행 바는 실제 생성률이 아닌, 생성 대기 상태를 시각적으로 표현하기 위한 UI 요소입니다.

close #191