### PR TITLE
fix: 포트폴리오 전략/면접 질문 생성 후 결과 페이지 이동 누락 오류 수정

### DIFF
--- a/src/features/interview/components/sections/InterviewConditionalPanel.tsx
+++ b/src/features/interview/components/sections/InterviewConditionalPanel.tsx
@@ -32,7 +32,8 @@ export default function InterviewConditionalPanel() {
   const dailyLimit = availability?.limitCount ?? DAILY_LIMIT;
   const isLimitReached = !availability?.canGenerate;
 
-  const isFormLocked = submitLoading;
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isFormLocked = submitLoading || isNavigating;
 
   const processingCount = useMemo(() => {
     return requestOrder.filter((id) => requests[id]?.status === 'PROCESSING').length;
@@ -56,6 +57,7 @@ export default function InterviewConditionalPanel() {
       const { resetForm } = useInterviewCreateFormStore.getState();
       resetForm();
 
+      setIsNavigating(true);
       router.push(`/interview/result/${response.interviewStrategyId}`);
     } catch (error) {
       console.error(error);
@@ -140,7 +142,12 @@ export default function InterviewConditionalPanel() {
           disabled={!selectedPortfolio || isLimitReached || isFormLocked || isAvailabilityLoading}
           className="flex w-full items-center justify-center gap-2 rounded-[10px] bg-blue-600 py-3.5 text-[15px] font-bold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {submitLoading ? (
+          {isNavigating ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              결과 페이지로 이동 중...
+            </>
+          ) : submitLoading ? (
             <>
               <Loader2 className="h-4 w-4 animate-spin" />
               생성 요청 중...

--- a/src/features/interview/hooks/useStartInterviewGeneration.tsx
+++ b/src/features/interview/hooks/useStartInterviewGeneration.tsx
@@ -26,19 +26,27 @@ export function useStartInterviewGeneration() {
 
     startSubmit();
 
+    let response: CreateInterviewResponse;
+
     try {
-      const response = await createInterview(payload);
-
-      addProcessingRequest(response.interviewStrategyId);
-
-      return response;
+      response = await createInterview(payload);
     } catch (err) {
       const message = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
-
       markSubmitFailed(message);
       toast.error(message);
       throw err;
     }
+
+    if (!response?.interviewStrategyId) {
+      console.error('[Interview] interviewStrategyId missing from API response:', response);
+      const message = '면접 질문 생성 결과를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.';
+      markSubmitFailed(message);
+      toast.error(message);
+      throw new Error(message);
+    }
+
+    addProcessingRequest(response.interviewStrategyId);
+    return response;
   };
 
   return { startInterviewGeneration };

--- a/src/features/strategy/components/sections/StrategyConditionPanel.tsx
+++ b/src/features/strategy/components/sections/StrategyConditionPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Info, Loader2, Sparkles, Timer } from 'lucide-react';
 import { JOB_LABEL_MAP } from '@/features/recruitment/constants/jobOptions';
@@ -56,7 +56,8 @@ export default function StrategyConditionPanel({
   const dailyLimit = availability?.limitCount ?? DAILY_LIMIT;
   const isLimitReached = !availability?.canGenerate;
 
-  const isFormLocked = submitLoading;
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isFormLocked = submitLoading || isNavigating;
 
   const processingCount = useMemo(() => {
     return requestOrder.filter((id) => requests[id]?.status === 'PROCESSING').length;
@@ -82,6 +83,7 @@ export default function StrategyConditionPanel({
 
     try {
       const response = await startStrategyGeneration();
+      setIsNavigating(true);
       router.push(`/strategy/result/${response.strategyId}`);
     } catch (error) {
       console.error(error);
@@ -229,10 +231,15 @@ export default function StrategyConditionPanel({
             disabled={formData.selectedExperienceIds.length === 0 || isLimitReached || isFormLocked}
             className="inline-flex h-12 w-full cursor-pointer items-center justify-center gap-2 rounded-[10px] bg-blue-600 px-4 text-[15px] font-bold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300 max-md:h-11"
           >
-            {submitLoading ? (
+            {isNavigating ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
-                전략 생성 요청 중...
+                결과 페이지로 이동 중...
+              </>
+            ) : submitLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                생성 요청 중...
               </>
             ) : (
               <>

--- a/src/features/strategy/components/ui/MobileStrategyGenerateBar.tsx
+++ b/src/features/strategy/components/ui/MobileStrategyGenerateBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Loader2, Sparkles } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
@@ -38,11 +38,15 @@ export default function MobileStrategyGenerateBar() {
     return selectedIndustry?.industryName ?? '';
   }, [formData.isIndustryOn, formData.selectedIndustryId, industryData]);
 
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isFormLocked = submitLoading || isNavigating;
+
   const handleGenerateClick = async () => {
-    if (formData.selectedExperienceIds.length === 0 || isLimitReached || submitLoading) return;
+    if (formData.selectedExperienceIds.length === 0 || isLimitReached || isFormLocked) return;
 
     try {
       const response = await startStrategyGeneration();
+      setIsNavigating(true);
       router.push(`/strategy/result/${response.strategyId}`);
     } catch (error) {
       console.error(error);
@@ -72,15 +76,18 @@ export default function MobileStrategyGenerateBar() {
           <Button
             type="button"
             onClick={handleGenerateClick}
-            disabled={
-              formData.selectedExperienceIds.length === 0 || isLimitReached || submitLoading
-            }
+            disabled={formData.selectedExperienceIds.length === 0 || isLimitReached || isFormLocked}
             className="inline-flex h-11 flex-1 cursor-pointer items-center justify-center gap-2 rounded-[10px] bg-blue-600 px-4 text-[14px] font-bold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300"
           >
-            {submitLoading ? (
+            {isNavigating ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
-                전략 생성 요청 중...
+                결과 페이지로 이동 중...
+              </>
+            ) : submitLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                생성 요청 중...
               </>
             ) : (
               <>

--- a/src/features/strategy/hooks/useStartStrategyGeneration.tsx
+++ b/src/features/strategy/hooks/useStartStrategyGeneration.tsx
@@ -28,19 +28,27 @@ export function useStartStrategyGeneration() {
 
     startSubmit();
 
+    let response: CreateStrategyResponse;
+
     try {
-      const response = await createStrategy(payload);
-
-      addProcessingRequest(response.strategyId);
-
-      return response;
+      response = await createStrategy(payload);
     } catch (err) {
       const message = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
-
       markSubmitFailed(message);
       toast.error(message);
       throw err;
     }
+
+    if (!response?.strategyId) {
+      console.error('[Strategy] strategyId missing from API response:', response);
+      const message = '포트폴리오 전략 생성 결과를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.';
+      markSubmitFailed(message);
+      toast.error(message);
+      throw new Error(message);
+    }
+
+    addProcessingRequest(response.strategyId);
+    return response;
   };
 
   return { startStrategyGeneration };


### PR DESCRIPTION
## 작업 내용

- **생성 응답 ID 누락 시 결과 페이지 이동 방지**
  - 포트폴리오 전략/면접 질문 생성 응답에 결과 페이지 이동용 ID가 없을 경우 실패 처리
  - 결과 ID 누락 시 `addProcessingRequest` 및 결과 페이지 이동이 실행되지 않도록 방어
- **결과 페이지 이동 중 생성 버튼 상태 처리**
  - 생성 요청 중/결과 페이지 이동 중 생성 버튼 재클릭 방지
  - 결과 페이지 이동 중 버튼 문구를 `결과 페이지로 이동 중...`으로 표시

## 리뷰 필요

1. 포폴 전략/면접 질문 생성 후 결과 페이지로 리다이렉트 되는지 확인 부탁드립니다.
2. 생성 응답에 `strategyId` / `interviewStrategyId`가 없을 때 실패 처리 흐름이 적절한지 확인 부탁드립니다.
3. `isNavigating` 기준으로 생성 버튼과 조건 입력 영역을 비활성화하는 범위가 적절한지 확인 부탁드립니다.

close #188