### PR TITLE
fix: 경험 등록/수정 오류 수정

### DIFF
--- a/src/features/experience/components/sections/ExperienceSection.tsx
+++ b/src/features/experience/components/sections/ExperienceSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ExperienceAddButton from '@/features/experience/components/ui/ExperienceAddButton';
 import ExperienceCard from '@/features/experience/components/ui/ExperienceCard';
 import ExperienceEmpty from '@/features/experience/components/ui/ExperienceEmpty';
@@ -18,9 +18,11 @@ export default function ExperienceSection() {
   const { data: filesData } = useFiles();
   const { data: experienceData } = useGetExperienceList();
   const files = filesData?.contents ?? [];
-  const experienceList = experienceData?.contents ?? [];
+  const experienceList = useMemo(() => {
+    return experienceData?.contents ?? [];
+  }, [experienceData?.contents]);
 
-  const [clientExperienceList, setClientExperienceList] = useState<Experience[]>(experienceList);
+  const [clientExperienceList, setClientExperienceList] = useState<Experience[]>([]);
 
   const { experience, closeDialog } = useExperienceDetailDialog();
 
@@ -30,6 +32,13 @@ export default function ExperienceSection() {
   const removeCompletedExtractionIds = useExperienceExtractionStore(
     (state) => state.removeCompletedExtractionIds,
   );
+
+  useEffect(() => {
+    setClientExperienceList((prev) => {
+      const tempItems = prev.filter((item) => item.experienceId < 0);
+      return [...tempItems, ...experienceList];
+    });
+  }, [experienceList]);
 
   useEffect(() => {
     if (completedExtractionIds.length === 0) return;

--- a/src/features/experience/queries.ts
+++ b/src/features/experience/queries.ts
@@ -81,6 +81,7 @@ export function useCreateExperience() {
         experienceContent: variables.experienceContent ?? '',
       };
       queryClient.setQueryData(experienceKeys.detail(data.experienceId), created);
+      queryClient.invalidateQueries({ queryKey: experienceKeys.all });
     },
     onError: (error) => {
       console.error('경험 등록 실패: ', error);


### PR DESCRIPTION
## 작업 내용

- 경험 등록 후 invalidateQuery를 통해 캐싱 무효화 진행
- 새로 고침 후 빈 리스트가 표시되는 오류 수정 (useEffect 추가)

## 리뷰 필요

1. 경험 등록/수정이 정상적으로 작동하는지 확인 필요

close #217
