### PR TITLE
fix: 로딩 중 Empty UI 노출 수정

### DIFF
--- a/src/features/bookmark/components/sections/BookmarkSection.tsx
+++ b/src/features/bookmark/components/sections/BookmarkSection.tsx
@@ -1,23 +1,36 @@
 'use client';
 
+import BookmarkSkeleton from '@/features/bookmark/components/ui/BookmarkSkeleton';
 import MyBookmarkEmpty from '@/features/bookmark/components/ui/MyBookmarkEmpty';
 import MyBookmarkList from '@/features/bookmark/components/ui/MyBookmarkList';
 import { useGetBookmarks } from '@/features/bookmark/queries';
 
 export default function BookmarkSection() {
-  const { data: bookmarks, isLoading, isError, error } = useGetBookmarks();
+  const { data, isLoading, isError, error } = useGetBookmarks();
+
+  const bookmarks = data?.content || [];
 
   return (
     <>
       {/* 북마크 개수 */}
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium text-gray-600">
-          총 {bookmarks?.content.length || 0}개의 북마크
+          총 {bookmarks.length ?? 0}개의 북마크
         </span>
       </div>
 
       {/* 빈 리스트 or 북마크 리스트 */}
-      {!bookmarks || bookmarks?.content.length === 0 ? <MyBookmarkEmpty /> : <MyBookmarkList />}
+      {isLoading ? (
+        <>
+          {Array.from({ length: 5 }, (_, idx) => (
+            <BookmarkSkeleton key={idx} />
+          ))}
+        </>
+      ) : bookmarks.length === 0 ? (
+        <MyBookmarkEmpty />
+      ) : (
+        <MyBookmarkList />
+      )}
     </>
   );
 }

--- a/src/features/bookmark/components/ui/BookmarkSkeleton.tsx
+++ b/src/features/bookmark/components/ui/BookmarkSkeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '@/shared/components/ui/skeleton';
+
+export default function BookmarkSkeleton() {
+  return (
+    <div className="flex items-center justify-between rounded-xl border border-gray-100 px-6 py-5">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-3.5 w-3.5" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <Skeleton className="h-5 w-56" />
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-3 w-3" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-6 w-12 rounded-md" />
+        <Skeleton className="h-9 w-9 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/file/components/sections/FileSection.tsx
+++ b/src/features/file/components/sections/FileSection.tsx
@@ -6,9 +6,8 @@ import { MAX_FILES } from '@/features/file/constants/maxFiles';
 import { useFiles } from '@/features/file/queries';
 
 export default function FileSection() {
-  const { data, isLoading, isError, error } = useFiles();
+  const { data } = useFiles();
 
-  const files = data?.contents || [];
   const currentFileCount = data && data.totalCount;
 
   return (
@@ -25,7 +24,7 @@ export default function FileSection() {
       </div>
 
       {/* 파일 테이블 */}
-      <FileTable files={files} />
+      <FileTable />
     </>
   );
 }

--- a/src/features/file/components/ui/FileSkeleton.tsx
+++ b/src/features/file/components/ui/FileSkeleton.tsx
@@ -1,0 +1,55 @@
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { TableCell, TableRow } from '@/shared/components/ui/table';
+
+interface FileSkeletonProps {
+  variant?: 'row' | 'card';
+}
+
+export default function FileSkeleton({ variant = 'row' }: FileSkeletonProps) {
+  if (variant === 'card') {
+    return (
+      <div className="flex items-center justify-between gap-3 px-4 py-3.5">
+        <div className="flex min-w-0 flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-14 rounded-full" />
+            <div className="flex items-center gap-1.5">
+              <Skeleton className="h-3.5 w-3.5 shrink-0" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          </div>
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <Skeleton className="h-8 w-8 rounded-md" />
+      </div>
+    );
+  }
+
+  return (
+    <TableRow>
+      <TableCell className="w-25 px-4 py-3.5">
+        <Skeleton className="h-5 w-14 rounded-full" />
+      </TableCell>
+
+      <TableCell className="px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4 shrink-0" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      </TableCell>
+
+      <TableCell className="w-25 px-4 py-3.5">
+        <Skeleton className="h-4 w-12" />
+      </TableCell>
+
+      <TableCell className="w-30 px-4 py-3.5">
+        <Skeleton className="h-4 w-20" />
+      </TableCell>
+
+      <TableCell className="w-18 px-4 py-3.5">
+        <div className="flex justify-center">
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/features/file/components/ui/FileTable.tsx
+++ b/src/features/file/components/ui/FileTable.tsx
@@ -1,6 +1,9 @@
-import { File } from '@/features/file/types';
+'use client';
+
+import FileSkeleton from '@/features/file/components/ui/FileSkeleton';
 import FileTableEmpty from '@/features/file/components/ui/FileTableEmpty';
 import FileTableRow from '@/features/file/components/ui/FileTableRow';
+import { useFiles } from '@/features/file/queries';
 import {
   Table,
   TableBody,
@@ -11,18 +14,27 @@ import {
 } from '@/shared/components/ui/table';
 import { cn } from '@/shared/lib/cn';
 
-interface FileTableProps {
-  files: File[];
-}
+export default function FileTable() {
+  const { data, isLoading } = useFiles();
 
-export default function FileTable({ files }: FileTableProps) {
+  const files = data?.contents || [];
+
   return (
     <>
       {/* Mobile: card list */}
       <div
-        className={cn('overflow-hidden rounded-xl divide-y divide-gray-100 lg:hidden', files.length > 0 && 'border border-gray-100')}
+        className={cn(
+          'overflow-hidden rounded-xl divide-y divide-gray-100 lg:hidden',
+          files.length > 0 && 'border border-gray-100',
+        )}
       >
-        {files.length === 0 ? (
+        {isLoading ? (
+          <>
+            {Array.from({ length: 5 }, (_, idx) => (
+              <FileSkeleton key={idx} variant="card" />
+            ))}
+          </>
+        ) : files.length === 0 ? (
           <FileTableEmpty />
         ) : (
           files.map((file) => <FileTableRow key={file.fileAssetId} file={file} variant="card" />)
@@ -52,7 +64,13 @@ export default function FileTable({ files }: FileTableProps) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {files.length === 0 ? (
+            {isLoading ? (
+              <>
+                {Array.from({ length: 5 }, (_, idx) => (
+                  <FileSkeleton key={idx} variant="row" />
+                ))}
+              </>
+            ) : files.length === 0 ? (
               <TableRow className="hover:bg-transparent">
                 <TableCell colSpan={5} className="p-0">
                   <FileTableEmpty />

--- a/src/features/interview/components/layout/InterviewHistorySidebar.tsx
+++ b/src/features/interview/components/layout/InterviewHistorySidebar.tsx
@@ -8,7 +8,7 @@ import { useGetInterviewList } from '@/features/interview/queries';
 import { createInterviewHistoryItems } from '@/features/interview/utils/createInterviewHistoryItems';
 
 export default function InterviewHistorySidebar() {
-  const { data: interviewData } = useGetInterviewList();
+  const { data: interviewData, isLoading } = useGetInterviewList();
 
   const requests = useInterviewGenerationStore((state) => state.requests);
   const requestOrder = useInterviewGenerationStore((state) => state.requestOrder);
@@ -52,6 +52,7 @@ export default function InterviewHistorySidebar() {
       items={items}
       processingLabel="생성 중"
       processingItems={processingItems}
+      isLoading={isLoading}
     />
   );
 }

--- a/src/features/strategy/components/layout/StrategyHistorySidebar.tsx
+++ b/src/features/strategy/components/layout/StrategyHistorySidebar.tsx
@@ -8,7 +8,7 @@ import { createStrategyHistoryItems } from '@/features/strategy/utils/createStra
 import { useGetStrategyList } from '@/features/strategy/queries';
 
 export default function StrategyHistorySidebar() {
-  const { data: strategyData } = useGetStrategyList();
+  const { data: strategyData, isLoading } = useGetStrategyList();
 
   const requests = useStrategyGenerationStore((state) => state.requests);
   const requestOrder = useStrategyGenerationStore((state) => state.requestOrder);
@@ -50,6 +50,7 @@ export default function StrategyHistorySidebar() {
       items={items}
       processingLabel="생성 중"
       processingItems={processingItems}
+      isLoading={isLoading}
     />
   );
 }

--- a/src/shared/components/layout/HistorySidebar.tsx
+++ b/src/shared/components/layout/HistorySidebar.tsx
@@ -18,6 +18,7 @@ import {
   useSidebar,
 } from '@/shared/components/ui/sidebar';
 import { HistorySidebarItem } from '@/shared/types';
+import SidebarItemSkeleton from '@/shared/components/ui/SidebarItemSkeleton';
 
 interface HistorySidebarProps {
   title: string;
@@ -28,6 +29,7 @@ interface HistorySidebarProps {
   items: HistorySidebarItem[];
   processingLabel?: string;
   processingItems?: HistorySidebarItem[];
+  isLoading: boolean;
 }
 
 export default function HistorySidebar({
@@ -39,6 +41,7 @@ export default function HistorySidebar({
   items,
   processingLabel,
   processingItems = [],
+  isLoading,
 }: HistorySidebarProps) {
   const pathname = usePathname();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -151,7 +154,19 @@ export default function HistorySidebar({
 
           <SidebarGroupContent>
             <SidebarMenu className="gap-0.5 group-data-[collapsible=icon]:items-center">
-              {renderMenuItems(items)}
+              {isLoading ? (
+                <>
+                  {Array.from({ length: 3 }, (_, idx) => (
+                    <SidebarItemSkeleton key={idx} />
+                  ))}
+                </>
+              ) : items.length === 0 ? (
+                <span className="px-3 py-1 items-center text-center text-xs text-gray-500">
+                  아직 생성된 {title}이 없어요
+                </span>
+              ) : (
+                renderMenuItems(items, false)
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/src/shared/components/ui/SidebarItemSkeleton.tsx
+++ b/src/shared/components/ui/SidebarItemSkeleton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { SidebarMenuItem, SidebarMenuButton } from '@/shared/components/ui/sidebar';
+
+export default function SidebarItemSkeleton() {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild className="h-auto p-0">
+        <div className="flex gap-2.5 rounded-lg border border-transparent px-3 py-2.5 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0">
+          <div className="flex h-4 w-4 shrink-0 items-center justify-center">
+            <Skeleton className="h-1.5 w-1.5 rounded-full" />
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-1.5 group-data-[collapsible=icon]:hidden">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-2.5 w-16" />
+          </div>
+        </div>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}


### PR DESCRIPTION
## 작업 내용

- 자료 정리 > 파일 관리에서 로딩 스켈레톤 추가
- HistoryBar 내에서, isLoading을 props로 전달 받아 로딩 중 스켈레톤 노출하도록 수정
- HistoryBar item의 길이가 0일 경우, 빈 상태를 표시하는 텍스트 추가
- 마이페이지 > 북마크에서 로딩 스켈레톤 추가

## 리뷰 필요

1. 로딩 중 스켈레톤 처리가 누락된 부분이 있는지 확인 필요
2. 스켈레톤 처리 및 빈 상태 UI가 적절한지 확인 필요

close #221 
