### PR TITLE
fix: ts 엔진 css 인식 오류 수정

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## 작업 내용

- ts엔진 타입 검사가 강화됨에 따라, css 파일을 import하는 구문에서 오류가 발생함
- css 모듈을 명시적으로 선언해주어 오류 방지

## 리뷰 필요

1. 전역 layout 파일에서 `import '@/app/globals.css'` 구문의 오류 발생하던 부분의 가장 적절한 해결 방법이라고 판단해서 해당 방식으로 진행했습니다. 다른 더 좋은 방법이 있다면 제시 부탁드립니다. 

close #227 
