### PR TITLE
fix: 모바일 검색바 닫기 시 검색 상태 초기화

### DIFF
--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Search, X } from 'lucide-react';
 import SearchBar from '@/shared/components/ui/SearchBar';
 import ProfileMenu from '@/features/auth/components/ui/ProfileMenu';
@@ -27,8 +27,20 @@ interface HeaderContentProps {
 }
 
 function HeaderContent({ currentPath }: HeaderContentProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
   const [isTabletSearchOpen, setIsTabletSearchOpen] = useState(false);
+
+  const handleMobileSearchClose = () => {
+    setIsMobileSearchOpen(false);
+    if (searchParams.get('search')) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('search');
+      const nextUrl = params.toString() ? `${currentPath}?${params.toString()}` : currentPath;
+      router.replace(nextUrl, { scroll: false });
+    }
+  };
 
   const showSearchBar = currentPath === '/';
 
@@ -116,7 +128,7 @@ function HeaderContent({ currentPath }: HeaderContentProps) {
               <button
                 type="button"
                 aria-label="검색 닫기"
-                onClick={() => setIsMobileSearchOpen(false)}
+                onClick={handleMobileSearchClose}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-200 text-gray-600 cursor-pointer"
               >
                 <X className="h-3.5 w-3.5" strokeWidth={1.75} />


### PR DESCRIPTION
## 작업 내용

- 모바일 검색바 닫기 버튼 클릭 시 검색 UI를 닫도록 처리
- URL의 `search` query parameter가 남아 있는 경우 함께 제거
- 입력값만 사라지고 실제 검색 키워드는 유지되는 상태 불일치 방지

## 리뷰 필요

- 모바일에서 검색어 입력 후 닫기 버튼 클릭 시 검색 UI가 닫히는지 확인 부탁드립니다.
- 닫기 버튼 클릭 후 URL의 `search` query parameter가 제거되는지 확인 부탁드립니다.
- 검색어 초기화 후 기존 목록 상태로 정상 복귀하는지 확인 부탁드립니다.

close #161