### PR TITLE
refactor: 생성 대기 화면 높이 조정

### DIFF
--- a/src/shared/components/ui/GenerationPendingState.tsx
+++ b/src/shared/components/ui/GenerationPendingState.tsx
@@ -30,8 +30,8 @@ export default function GenerationPendingState({
     <section
       role="status"
       aria-live="polite"
-      aria-labelledby={titleId}
-      className="flex min-h-120 w-full flex-col items-center justify-center py-12 text-center max-md:min-h-105 max-md:py-8"
+      aria-label={title}
+      className="flex min-h-[calc(100dvh-160px)] w-full flex-col items-center justify-center py-12 text-center max-md:min-h-[calc(100dvh-120px)] max-md:py-8"
     >
       <GeneratingIcon />
 


### PR DESCRIPTION
## 작업 내용

- 생성 대기 화면의 최소 높이를 viewport 기준으로 조정
- 생성 중 화면 하단에 footer가 바로 노출되는 문제 완화
- 기존 생성 대기 UI의 문구, 진행 바, tip 영역 동작 유지

## 리뷰 필요

- 생성 대기 화면이 데스크톱/모바일에서 자연스럽게 중앙에 배치되는지 확인 부탁드립니다.

close #236 
