### PR TITLE
feat: 생성 기능 주간 사용 횟수 UI 반영

### DIFF
--- a/src/features/experience/actions.ts
+++ b/src/features/experience/actions.ts
@@ -14,6 +14,7 @@ import {
 } from '@/features/experience/types';
 import { privateFetch } from '@/shared/api/httpClient';
 import { ApiResponse } from '@/shared/types/api';
+import { GetGenerationAvailabilityResponse } from '@/shared/types/generation';
 
 // 경험 목록 조회
 export async function getExperienceList(): Promise<ApiResponse<GetExperienceListResponse>> {
@@ -88,4 +89,11 @@ export async function getExtractedExperience(
     `/api/v1/experiences/extractions/${extractedExperienceId}`,
   );
   return response;
+}
+
+// 경험 추출 사용 횟수 조회
+export async function getExperienceAvailability(): Promise<
+  ApiResponse<GetGenerationAvailabilityResponse>
+> {
+  return await privateFetch<GetGenerationAvailabilityResponse>('/api/v1/experience/availability');
 }

--- a/src/features/experience/components/sections/ExperienceSection.tsx
+++ b/src/features/experience/components/sections/ExperienceSection.tsx
@@ -6,15 +6,21 @@ import ExperienceEmpty from '@/features/experience/components/ui/ExperienceEmpty
 import ExperienceExtractBanner from '@/features/experience/components/ui/ExperienceExtractBanner';
 import { Experience } from '@/features/experience/types';
 import ExperienceExtractDialog from '@/features/experience/components/ui/ExperienceExtractDialog';
-import { useGetExperienceList } from '@/features/experience/queries';
+import { useGetExperienceAvailability, useGetExperienceList } from '@/features/experience/queries';
 import { useExperienceExtractionStore } from '@/features/experience/stores/useExperienceExtractionStore';
 import { getExtractedExperience } from '@/features/experience/actions';
 import ExperienceDetailDialog from '@/features/experience/components/ui/ExperienceDetailDialog';
 import ExperienceItemWrapper from '@/features/experience/components/ui/ExperienceItemWrapper';
 import ExperienceListItemSkeleton from '@/features/experience/components/ui/ExperienceListItemSkeleton';
+import { WEEKLY_LIMIT, WEEKLY_USAGE } from '@/features/experience/constants/limit';
 
 export default function ExperienceSection() {
   const { data: experienceData, isLoading } = useGetExperienceList();
+  const { data: availability, isLoading: isAvailabilityLoading } = useGetExperienceAvailability();
+
+  const weeklyUsage = availability?.usedCount ?? WEEKLY_USAGE;
+  const weeklyLimit = availability?.limitCount ?? WEEKLY_LIMIT;
+  const isLimitReached = availability?.canGenerate === false;
 
   const experienceList = useMemo(() => {
     return experienceData?.contents ?? [];
@@ -97,9 +103,14 @@ export default function ExperienceSection() {
 
   return (
     <>
-      {/* TODO: 경험 추출 availability API 추가 후 사용 횟수 UI 연결 */}
       {/* 경험 추출 배너 */}
-      <ExperienceExtractBanner />
+      <ExperienceExtractBanner
+        usageLabel="이번 주 사용 횟수"
+        usedCount={weeklyUsage}
+        limitCount={weeklyLimit}
+        isUsageLoading={isAvailabilityLoading}
+        isLimitReached={isLimitReached}
+      />
 
       {/* 경험 개수 표시 */}
       <div className="flex items-center justify-between">

--- a/src/features/experience/components/sections/ExperienceSection.tsx
+++ b/src/features/experience/components/sections/ExperienceSection.tsx
@@ -6,21 +6,15 @@ import ExperienceEmpty from '@/features/experience/components/ui/ExperienceEmpty
 import ExperienceExtractBanner from '@/features/experience/components/ui/ExperienceExtractBanner';
 import { Experience } from '@/features/experience/types';
 import ExperienceExtractDialog from '@/features/experience/components/ui/ExperienceExtractDialog';
-import { useGetExperienceAvailability, useGetExperienceList } from '@/features/experience/queries';
 import { useExperienceExtractionStore } from '@/features/experience/stores/useExperienceExtractionStore';
 import { getExtractedExperience } from '@/features/experience/actions';
 import ExperienceDetailDialog from '@/features/experience/components/ui/ExperienceDetailDialog';
 import ExperienceItemWrapper from '@/features/experience/components/ui/ExperienceItemWrapper';
 import ExperienceListItemSkeleton from '@/features/experience/components/ui/ExperienceListItemSkeleton';
-import { WEEKLY_LIMIT, WEEKLY_USAGE } from '@/features/experience/constants/limit';
+import { useGetExperienceList } from '@/features/experience/queries';
 
 export default function ExperienceSection() {
   const { data: experienceData, isLoading } = useGetExperienceList();
-  const { data: availability, isLoading: isAvailabilityLoading } = useGetExperienceAvailability();
-
-  const weeklyUsage = availability?.usedCount ?? WEEKLY_USAGE;
-  const weeklyLimit = availability?.limitCount ?? WEEKLY_LIMIT;
-  const isLimitReached = availability?.canGenerate === false;
 
   const experienceList = useMemo(() => {
     return experienceData?.contents ?? [];
@@ -104,13 +98,7 @@ export default function ExperienceSection() {
   return (
     <>
       {/* 경험 추출 배너 */}
-      <ExperienceExtractBanner
-        usageLabel="이번 주 사용 횟수"
-        usedCount={weeklyUsage}
-        limitCount={weeklyLimit}
-        isUsageLoading={isAvailabilityLoading}
-        isLimitReached={isLimitReached}
-      />
+      <ExperienceExtractBanner />
 
       {/* 경험 개수 표시 */}
       <div className="flex items-center justify-between">

--- a/src/features/experience/components/ui/ExperienceExtractBanner.tsx
+++ b/src/features/experience/components/ui/ExperienceExtractBanner.tsx
@@ -1,22 +1,18 @@
+'use client';
+
 import { SparklesIcon } from 'lucide-react';
 import ExperienceExtractButton from '@/features/experience/components/ui/ExperienceExtractButton';
 import GenerationUsageCard from '@/shared/components/ui/GenerationUsageCard';
+import { WEEKLY_USAGE, WEEKLY_LIMIT } from '@/features/experience/constants/limit';
+import { useGetExperienceAvailability } from '@/features/experience/queries';
 
-interface ExperienceExtractBannerProps {
-  usageLabel: string;
-  usedCount: number;
-  limitCount: number;
-  isUsageLoading?: boolean;
-  isLimitReached?: boolean;
-}
+export default function ExperienceExtractBanner() {
+  const { data: availability, isLoading: isAvailabilityLoading } = useGetExperienceAvailability();
 
-export default function ExperienceExtractBanner({
-  usageLabel,
-  usedCount,
-  limitCount,
-  isUsageLoading = false,
-  isLimitReached = false,
-}: ExperienceExtractBannerProps) {
+  const weeklyUsage = availability?.usedCount ?? WEEKLY_USAGE;
+  const weeklyLimit = availability?.limitCount ?? WEEKLY_LIMIT;
+  const isLimitReached = availability?.canGenerate === false;
+
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-blue-100 bg-blue-50 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <div className="flex flex-1 items-center gap-3.5">
@@ -35,13 +31,13 @@ export default function ExperienceExtractBanner({
         <GenerationUsageCard
           variant="compact"
           label="이번 주 사용 횟수"
-          usedCount={usedCount}
-          limitCount={limitCount}
-          isLoading={isUsageLoading}
+          usedCount={weeklyUsage}
+          limitCount={weeklyLimit}
+          isLoading={isAvailabilityLoading}
           className="max-sm:w-full"
         />
 
-        <ExperienceExtractButton disabled={isLimitReached || isUsageLoading} />
+        <ExperienceExtractButton disabled={isLimitReached || isAvailabilityLoading} />
       </div>
     </div>
   );

--- a/src/features/experience/components/ui/ExperienceExtractBanner.tsx
+++ b/src/features/experience/components/ui/ExperienceExtractBanner.tsx
@@ -1,7 +1,22 @@
 import { SparklesIcon } from 'lucide-react';
 import ExperienceExtractButton from '@/features/experience/components/ui/ExperienceExtractButton';
+import GenerationUsageCard from '@/shared/components/ui/GenerationUsageCard';
 
-export default function ExperienceExtractBanner() {
+interface ExperienceExtractBannerProps {
+  usageLabel: string;
+  usedCount: number;
+  limitCount: number;
+  isUsageLoading?: boolean;
+  isLimitReached?: boolean;
+}
+
+export default function ExperienceExtractBanner({
+  usageLabel,
+  usedCount,
+  limitCount,
+  isUsageLoading = false,
+  isLimitReached = false,
+}: ExperienceExtractBannerProps) {
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-blue-100 bg-blue-50 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <div className="flex flex-1 items-center gap-3.5">
@@ -15,7 +30,19 @@ export default function ExperienceExtractBanner() {
           </span>
         </div>
       </div>
-      <ExperienceExtractButton />
+
+      <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
+        <GenerationUsageCard
+          variant="compact"
+          label="이번 주 사용 횟수"
+          usedCount={usedCount}
+          limitCount={limitCount}
+          isLoading={isUsageLoading}
+          className="max-sm:w-full"
+        />
+
+        <ExperienceExtractButton disabled={isLimitReached || isUsageLoading} />
+      </div>
     </div>
   );
 }

--- a/src/features/experience/components/ui/ExperienceExtractButton.tsx
+++ b/src/features/experience/components/ui/ExperienceExtractButton.tsx
@@ -5,16 +5,30 @@ import { useExperienceExtractionStore } from '@/features/experience/stores/useEx
 import { Button } from '@/shared/components/ui/button';
 import { LoaderCircleIcon } from 'lucide-react';
 
-export default function ExperienceExtractButton() {
+interface ExperienceExtractButtonProps {
+  disabled?: boolean;
+}
+
+export default function ExperienceExtractButton({
+  disabled = false,
+}: ExperienceExtractButtonProps) {
   const { openDialog } = useExperienceExtractDialog();
   const generationStatus = useExperienceExtractionStore((state) => state.generationStatus);
   const isExtracting = generationStatus === 'PROCESSING';
 
+  const isDisabled = disabled || isExtracting;
+
+  const handleOpenDialog = () => {
+    if (isDisabled) return;
+
+    openDialog();
+  };
+
   return (
     <Button
       type="button"
-      onClick={openDialog}
-      disabled={isExtracting}
+      onClick={handleOpenDialog}
+      disabled={isDisabled}
       className="shrink-0 rounded-lg bg-gray-900 px-4 py-2.5 text-[13px] font-semibold text-white hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-70"
     >
       {isExtracting ? (

--- a/src/features/experience/constants/limit.ts
+++ b/src/features/experience/constants/limit.ts
@@ -1,0 +1,2 @@
+export const WEEKLY_USAGE = 0;
+export const WEEKLY_LIMIT = 7;

--- a/src/features/experience/queries.ts
+++ b/src/features/experience/queries.ts
@@ -2,6 +2,7 @@ import {
   createExperience,
   deleteExperience,
   getExperience,
+  getExperienceAvailability,
   getExperienceList,
   updateExperience,
 } from '@/features/experience/actions';
@@ -16,6 +17,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 export const experienceKeys = {
   all: ['experiences'] as const,
   detail: (exprienceId: number) => [...experienceKeys.all, exprienceId] as const,
+  availability: () => [...experienceKeys.all, 'availability'] as const,
 };
 
 export const experienceListQueryOptions = () => ({
@@ -128,3 +130,23 @@ export function useDeleteExperience() {
     },
   });
 }
+
+// 경험 추출 사용 횟수 조회
+export function useGetExperienceAvailability(enabled = true) {
+  return useQuery(getExperienceAvailabilityQueryOptions(enabled));
+}
+
+export const getExperienceAvailabilityQueryOptions = (enabled = true) => ({
+  queryKey: experienceKeys.availability(),
+  queryFn: async () => {
+    const response = await getExperienceAvailability();
+
+    if (!response.success) {
+      return Promise.reject(response);
+    }
+
+    return response.data;
+  },
+  staleTime: 60 * 1000,
+  enabled,
+});

--- a/src/features/interview/actions.ts
+++ b/src/features/interview/actions.ts
@@ -3,12 +3,12 @@
 import {
   CreateInterviewRequest,
   CreateInterviewResponse,
-  GetInterviewAvailablityResponse,
   GetInterviewListResponse,
   GetInterviewResponse,
 } from '@/features/interview/types';
 import { privateFetch } from '@/shared/api/httpClient';
 import { ApiResponse } from '@/shared/types/api';
+import { GetGenerationAvailabilityResponse } from '@/shared/types/generation';
 
 // 면접 질문 목록 조회
 export async function getInterviewList(): Promise<ApiResponse<GetInterviewListResponse>> {
@@ -57,9 +57,9 @@ export async function deleteInterview(interviewStrategyId: number): Promise<ApiR
 
 // 면접 질문 생성 사용 횟수
 export async function getInterviewAvailability(): Promise<
-  ApiResponse<GetInterviewAvailablityResponse>
+  ApiResponse<GetGenerationAvailabilityResponse>
 > {
-  return await privateFetch<GetInterviewAvailablityResponse>(
+  return await privateFetch<GetGenerationAvailabilityResponse>(
     '/api/v1/interview-strategies/availability',
   );
 }

--- a/src/features/interview/components/sections/InterviewConditionalPanel.tsx
+++ b/src/features/interview/components/sections/InterviewConditionalPanel.tsx
@@ -9,7 +9,7 @@ import { useInterviewCreateFormStore } from '@/features/interview/stores/useInte
 import { useInterviewGenerationStore } from '@/features/interview/stores/useInterviewGenerationStore';
 import { useStartInterviewGeneration } from '@/features/interview/hooks/useStartInterviewGeneration';
 import { useGetInterviewAvailability } from '@/features/interview/queries';
-import { TODAY_USAGE, DAILY_LIMIT } from '@/features/interview/constants/limit';
+import { WEEKLY_USAGE, WEEKLY_LIMIT } from '@/features/interview/constants/limit';
 import GenerationUsageCard from '@/shared/components/ui/GenerationUsageCard';
 
 export default function InterviewConditionalPanel() {
@@ -28,8 +28,8 @@ export default function InterviewConditionalPanel() {
 
   const { data: availability, isLoading: isAvailabilityLoading } = useGetInterviewAvailability();
 
-  const todayUsage = availability?.usedCount ?? TODAY_USAGE;
-  const dailyLimit = availability?.limitCount ?? DAILY_LIMIT;
+  const weeklyUsage = availability?.usedCount ?? WEEKLY_USAGE;
+  const weeklyLimit = availability?.limitCount ?? WEEKLY_LIMIT;
   const isLimitReached = !availability?.canGenerate;
 
   const [isNavigating, setIsNavigating] = useState(false);
@@ -130,9 +130,9 @@ export default function InterviewConditionalPanel() {
         </div>
 
         <GenerationUsageCard
-          label="오늘 사용 횟수"
-          usedCount={todayUsage}
-          limitCount={dailyLimit}
+          label="이번 주 사용 횟수"
+          usedCount={weeklyUsage}
+          limitCount={weeklyLimit}
           isLoading={isAvailabilityLoading}
         />
 

--- a/src/features/interview/components/ui/InterviewGuideCard.tsx
+++ b/src/features/interview/components/ui/InterviewGuideCard.tsx
@@ -1,5 +1,5 @@
 import { Info } from 'lucide-react';
-import { DAILY_LIMIT, TODAY_USAGE } from '@/features/interview/constants/limit';
+import { WEEKLY_LIMIT, WEEKLY_USAGE } from '@/features/interview/constants/limit';
 
 export default function InterviewGuideCard() {
   return (
@@ -33,7 +33,8 @@ export default function InterviewGuideCard() {
             <div className="flex flex-col gap-0.5">
               <span className="text-[13px] font-semibold text-gray-800">하루 1회 생성 제한</span>
               <span className="text-xs leading-normal text-gray-500">
-                면접 질문 생성은 하루 최대 {DAILY_LIMIT}회 가능합니다 (오늘 {TODAY_USAGE}회 사용)
+                면접 질문 생성은 하루 최대 {WEEKLY_LIMIT}회 가능합니다 (이번 주 {WEEKLY_USAGE}회
+                사용)
               </span>
             </div>
           </div>

--- a/src/features/interview/components/ui/InterviewGuideCard.tsx
+++ b/src/features/interview/components/ui/InterviewGuideCard.tsx
@@ -31,9 +31,9 @@ export default function InterviewGuideCard() {
           <div className="flex gap-3 border-b border-blue-50 px-4 py-3.5 md:px-5">
             <div className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
             <div className="flex flex-col gap-0.5">
-              <span className="text-[13px] font-semibold text-gray-800">하루 1회 생성 제한</span>
+              <span className="text-[13px] font-semibold text-gray-800">주간 7회 생성 제한</span>
               <span className="text-xs leading-normal text-gray-500">
-                면접 질문 생성은 하루 최대 {WEEKLY_LIMIT}회 가능합니다 (이번 주 {WEEKLY_USAGE}회
+                면접 질문 생성은 주간 최대 {WEEKLY_LIMIT}회 가능합니다 (이번 주 {WEEKLY_USAGE}회
                 사용)
               </span>
             </div>

--- a/src/features/interview/constants/limit.ts
+++ b/src/features/interview/constants/limit.ts
@@ -1,2 +1,2 @@
-export const TODAY_USAGE = 0;
-export const DAILY_LIMIT = 1;
+export const WEEKLY_USAGE = 0;
+export const WEEKLY_LIMIT = 7;

--- a/src/features/strategy/actions.ts
+++ b/src/features/strategy/actions.ts
@@ -3,12 +3,12 @@
 import {
   CreateStrategyRequest,
   CreateStrategyResponse,
-  GetStrategyAvailablityResponse,
   GetStrategyDetailResponse,
   GetStrategyListResponse,
 } from '@/features/strategy/types';
 import { privateFetch } from '@/shared/api/httpClient';
 import { ApiResponse } from '@/shared/types/api';
+import { GetGenerationAvailabilityResponse } from '@/shared/types/generation';
 
 // 포폴 전략 목록 조회
 export async function getStrategyList(): Promise<ApiResponse<GetStrategyListResponse>> {
@@ -61,9 +61,9 @@ export async function deleteStrategy(strategyId: number): Promise<ApiResponse<nu
 
 // 포폴 전략 생성 사용 횟수 조회
 export async function getStrategyAvailability(): Promise<
-  ApiResponse<GetStrategyAvailablityResponse>
+  ApiResponse<GetGenerationAvailabilityResponse>
 > {
-  return await privateFetch<GetStrategyAvailablityResponse>('/api/v1/strategies/availability');
+  return await privateFetch<GetGenerationAvailabilityResponse>('/api/v1/strategies/availability');
 }
 
 type ApiFailureLike = {

--- a/src/features/strategy/components/sections/StrategyConditionPanel.tsx
+++ b/src/features/strategy/components/sections/StrategyConditionPanel.tsx
@@ -18,7 +18,7 @@ import { useStrategyGenerationStore } from '@/features/strategy/stores/useStrate
 import { useStrategyCreateFormStore } from '@/features/strategy/stores/useCreateStrategyFormStore';
 import { Button } from '@/shared/components/ui/button';
 import { useGetStrategyAvailability } from '@/features/strategy/queries';
-import { TODAY_USAGE, DAILY_LIMIT } from '@/features/strategy/constants/limit';
+import { WEEKLY_USAGE, WEEKLY_LIMIT } from '@/features/strategy/constants/limit';
 import { cn } from '@/shared/lib/cn';
 import { useGetIndustryList } from '@/features/industry/queries';
 import GenerationUsageCard from '@/shared/components/ui/GenerationUsageCard';
@@ -52,8 +52,8 @@ export default function StrategyConditionPanel({
 
   const { data: availability, isLoading: isAvailabilityLoading } = useGetStrategyAvailability();
 
-  const todayUsage = availability?.usedCount ?? TODAY_USAGE;
-  const dailyLimit = availability?.limitCount ?? DAILY_LIMIT;
+  const weeklyUsage = availability?.usedCount ?? WEEKLY_USAGE;
+  const weeklyLimit = availability?.limitCount ?? WEEKLY_LIMIT;
   const isLimitReached = !availability?.canGenerate;
 
   const [isNavigating, setIsNavigating] = useState(false);
@@ -216,9 +216,9 @@ export default function StrategyConditionPanel({
       </div>
 
       <GenerationUsageCard
-        label="오늘 사용 횟수"
-        usedCount={todayUsage}
-        limitCount={dailyLimit}
+        label="이번 주 사용 횟수"
+        usedCount={weeklyUsage}
+        limitCount={weeklyLimit}
         isLoading={isAvailabilityLoading}
         className="max-md:px-3.5 max-md:py-2.5"
       />

--- a/src/features/strategy/components/ui/MobileStrategyGenerateBar.tsx
+++ b/src/features/strategy/components/ui/MobileStrategyGenerateBar.tsx
@@ -6,7 +6,7 @@ import { Loader2, Sparkles } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
 import { JOB_LABEL_MAP } from '@/features/recruitment/constants/jobOptions';
 import { useGetStrategyAvailability } from '@/features/strategy/queries';
-import { TODAY_USAGE, DAILY_LIMIT } from '@/features/strategy/constants/limit';
+import { WEEKLY_USAGE, WEEKLY_LIMIT } from '@/features/strategy/constants/limit';
 import { useStartStrategyGeneration } from '@/features/strategy/hooks/useStartStrategyGeneration';
 import { useStrategyGenerationStore } from '@/features/strategy/stores/useStrategyGenerationStore';
 import { useStrategyCreateFormStore } from '@/features/strategy/stores/useCreateStrategyFormStore';
@@ -22,8 +22,8 @@ export default function MobileStrategyGenerateBar() {
   const { data: availability } = useGetStrategyAvailability();
   const { data: industryData } = useGetIndustryList();
 
-  const todayUsage = availability?.usedCount ?? TODAY_USAGE;
-  const dailyLimit = availability?.limitCount ?? DAILY_LIMIT;
+  const todayUsage = availability?.usedCount ?? WEEKLY_USAGE;
+  const dailyLimit = availability?.limitCount ?? WEEKLY_LIMIT;
   const isLimitReached = !availability?.canGenerate;
 
   const selectedIndustryName = useMemo(() => {

--- a/src/features/strategy/constants/limit.ts
+++ b/src/features/strategy/constants/limit.ts
@@ -1,2 +1,2 @@
-export const TODAY_USAGE = 0;
-export const DAILY_LIMIT = 1;
+export const WEEKLY_USAGE = 0;
+export const WEEKLY_LIMIT = 7;

--- a/src/shared/components/ui/GenerationUsageCard.tsx
+++ b/src/shared/components/ui/GenerationUsageCard.tsx
@@ -17,45 +17,48 @@ export default function GenerationUsageCard({
   className,
   variant = 'default',
 }: GenerationUsageCardProps) {
-  const isCompact = variant === 'compact';
+  if (variant === 'compact') {
+    return (
+      <div
+        className={cn(
+          'inline-flex h-10 items-center rounded-lg border border-blue-200 bg-white/80 px-3',
+          className,
+        )}
+      >
+        <span className="whitespace-nowrap text-[12px] font-semibold text-blue-600">{label}</span>
 
+        <div className="ml-2 flex items-baseline gap-1 whitespace-nowrap">
+          <span className="text-[15px] font-bold text-blue-700">{isLoading ? '-' : usedCount}</span>
+          <span className="text-[12px] font-medium text-blue-400">
+            / {isLoading ? '-' : `${limitCount}회`}
+          </span>
+        </div>
+      </div>
+    );
+  }
   return (
     <div
       className={cn(
-        'flex items-center justify-between border border-blue-100 bg-blue-50',
-        isCompact ? 'min-w-40 rounded-lg px-3 py-2' : 'rounded-[10px] px-4 py-3',
+        'flex items-center justify-between rounded-[10px] border border-blue-100 bg-blue-50 px-4 py-3',
         className,
       )}
     >
       <div className="flex flex-col gap-0.5">
-        <span
-          className={cn('font-medium text-blue-600', isCompact ? 'text-[10px]' : 'text-[11px]')}
-        >
-          {label}
-        </span>
-
+        <span className="text-[11px] font-medium text-blue-600">{label}</span>
         <div className="flex items-center gap-1">
-          <span
-            className={cn('font-bold text-blue-700', isCompact ? 'text-[16px]' : 'text-[20px]')}
-          >
-            {isLoading ? '-' : usedCount}
-          </span>
-
-          <span
-            className={cn('font-medium text-blue-400', isCompact ? 'text-[11px]' : 'text-[13px]')}
-          >
+          <span className="text-[20px] font-bold text-blue-700">{isLoading ? '-' : usedCount}</span>
+          <span className="text-[13px] font-medium text-blue-400">
             / {isLoading ? '-' : `${limitCount}회`}
           </span>
         </div>
       </div>
 
-      <div className={cn('flex items-center', isCompact ? 'gap-1' : 'gap-1.5')}>
+      <div className="flex items-center gap-1.5">
         {Array.from({ length: limitCount }).map((_, index) => (
-          <div
+          <span
             key={index}
             className={cn(
-              'rounded-full',
-              isCompact ? 'h-2 w-2' : 'h-2.5 w-2.5',
+              'h-2.5 w-2.5 rounded-full',
               index < usedCount ? 'bg-blue-500' : 'bg-blue-200',
             )}
           />

--- a/src/shared/types/generation.ts
+++ b/src/shared/types/generation.ts
@@ -26,3 +26,10 @@ export type GetGenerationStatusResponse = {
   status: GenerationRequestStatus;
   error: string | null;
 };
+
+export interface GetGenerationAvailabilityResponse {
+  usedCount: number;
+  limitCount: number;
+  canGenerate: boolean;
+  canRetry: boolean;
+}


### PR DESCRIPTION
## 작업 내용

- 생성 사용 횟수 조회 응답 타입을 `GenerationAvailabilityResponse`로 공통화
- 포트폴리오 전략/면접 질문 availability 응답에 `canRetry` 필드 반영
- 사용 횟수 UI 문구를 “이번 주 사용 횟수” 기준으로 변경
- 경험 추출 availability API 연동
- 경험 추출 배너에 사용 횟수 UI 적용
- `canGenerate` 기준으로 생성/추출 CTA 비활성화 처리

## 리뷰 필요

- availability API의 `usedCount`, `limitCount`는 기존 필드를 유지하되, 주간 사용 횟수 기준으로 표시했습니다.
- 새 생성 요청은 `canGenerate` 기준으로 버튼 비활성화 처리했습니다.
- `canRetry`는 응답 스펙에 포함되었지만, 현재 재시도 API/정책이 분리되어 있지 않아 후속 재시도 버튼 처리 시 반영 예정입니다.
- 추후 재시도 횟수 제한이 확정되면 `aiCallCount`, `maxAiCallCount` 또는 동일 의미의 필드 기준으로 안내 UI를 추가할 수 있습니다.

close #238