### PR TITLE
chore: 기업 상세페이지 링크 비활성화 처리

### DIFF
--- a/src/features/recruitment/components/ui/RecruitmentDetailOverview.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentDetailOverview.tsx
@@ -36,12 +36,15 @@ export default function RecruitmentDetailOverview({ recruitment }: RecruitmentDe
       <div className="flex flex-wrap items-center gap-2">
         <div className="flex items-center gap-1.5 rounded-md bg-blue-50 px-2.5 py-1">
           <Building2 className="h-3.5 w-3.5 text-blue-600" />
-          <Link
+          <span className="text-[13px] font-semibold text-blue-600 max-md:inline-block max-md:max-w-45 max-md:truncate">
+            {recruitment.companyName ?? '기업명'}
+          </span>
+          {/* <Link
             href={`/company/${recruitment.companyId}`}
             className="text-[13px] font-semibold text-blue-600 max-md:inline-block max-md:max-w-45 max-md:truncate"
           >
             {recruitment.companyName ?? '기업명'}
-          </Link>
+          </Link> */}
         </div>
 
         <span className="text-[13px] text-gray-400">·</span>


### PR DESCRIPTION
## 작업 내용

- 기업 상세페이지 링크 비활성화 처리

- 수정 결과 참고 이미지 (디자인 변경은 없습니다)
<img width="442" height="96" alt="스크린샷 2026-05-09 224133" src="https://github.com/user-attachments/assets/f6ffa302-b05a-4feb-9fa5-8730c652dfe6" />

## 리뷰 필요

x

close #242 
