### PR TITLE
fix: 경험 변경 시 추출 사용 횟수 재조회 방지

### DIFF
--- a/src/features/experience/queries.ts
+++ b/src/features/experience/queries.ts
@@ -16,12 +16,17 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const experienceKeys = {
   all: ['experiences'] as const,
-  detail: (exprienceId: number) => [...experienceKeys.all, exprienceId] as const,
-  availability: () => [...experienceKeys.all, 'availability'] as const,
+  list: () => [...experienceKeys.all, 'list'] as const,
+  detail: (experienceId: number) => [...experienceKeys.all, 'detail', experienceId] as const,
+};
+
+export const experienceExtractionKeys = {
+  all: ['experience-extractions'] as const,
+  availability: () => [...experienceExtractionKeys.all, 'availability'] as const,
 };
 
 export const experienceListQueryOptions = () => ({
-  queryKey: experienceKeys.all,
+  queryKey: experienceKeys.list(),
   queryFn: async () => {
     const result = await getExperienceList();
     if (!result.success) {
@@ -83,7 +88,10 @@ export function useCreateExperience() {
         experienceContent: variables.experienceContent ?? '',
       };
       queryClient.setQueryData(experienceKeys.detail(data.experienceId), created);
-      queryClient.invalidateQueries({ queryKey: experienceKeys.all });
+
+      queryClient.invalidateQueries({
+        queryKey: experienceKeys.list(),
+      });
     },
     onError: (error) => {
       console.error('경험 등록 실패: ', error);
@@ -104,6 +112,9 @@ export function useUpdateExperience() {
     },
     onSuccess: (data) => {
       queryClient.setQueryData(experienceKeys.detail(data.experienceId), data);
+      queryClient.invalidateQueries({
+        queryKey: experienceKeys.list(),
+      });
     },
     onError: (error) => {
       console.error('경험 수정 실패: ', error);
@@ -122,8 +133,14 @@ export function useDeleteExperience() {
       }
       return result.data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: experienceKeys.all });
+    onSuccess: (_, experienceId) => {
+      queryClient.invalidateQueries({
+        queryKey: experienceKeys.list(),
+      });
+
+      queryClient.removeQueries({
+        queryKey: experienceKeys.detail(experienceId),
+      });
     },
     onError: (error) => {
       console.error('경험 삭제 실패: ', error);
@@ -137,7 +154,7 @@ export function useGetExperienceAvailability(enabled = true) {
 }
 
 export const getExperienceAvailabilityQueryOptions = (enabled = true) => ({
-  queryKey: experienceKeys.availability(),
+  queryKey: experienceExtractionKeys.availability(),
   queryFn: async () => {
     const response = await getExperienceAvailability();
 


### PR DESCRIPTION
## 작업 내용

- 경험 목록 query key를 `experienceKeys.list()`로 분리
- 경험 추출 사용 횟수 query key를 `experienceExtractionKeys.availability()`로 분리
- 경험 등록/수정/삭제 시 `experienceKeys.list()`만 invalidate하도록 수정
- 경험 데이터 변경 시 추출 사용 횟수 API가 함께 재조회되지 않도록 조정

## 리뷰 필요

- 경험 등록/수정/삭제 이후 경험 목록은 정상 갱신되고, 추출 사용 횟수 API는 재조회되지 않는지 확인 부탁드립니다.
- 경험 추출 요청 성공 후 사용 횟수 갱신 처리는 `useStartExtractExperience` 훅 분리 이슈에서 별도로 반영 예정입니다.

close #243